### PR TITLE
Remove DD_AGENT_MAJOR_VERSION warning on versioned scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install_script.sh: install_script.sh.template
 	sed -e 's|AGENT_MAJOR_VERSION_PLACEHOLDER|6|' \
 		-e 's|INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER||' \
 		-e 's|INSTALL_INFO_VERSION_PLACEHOLDER||' \
+		-e 's|IS_LEGACY_SCRIPT_PLACEHOLDER|true|' \
 		-e 's|DEPRECATION_MESSAGE_PLACEHOLDER|echo -e "\\033[33m${DEPRECATION_MESSAGE}\\033[0m"|' \
 		install_script.sh.template > $@
 	chmod +x $@
@@ -24,6 +25,7 @@ install_script_agent6.sh: install_script.sh.template
 	sed -e 's|AGENT_MAJOR_VERSION_PLACEHOLDER|6|' \
 		-e 's|INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER| 6|' \
 		-e 's|INSTALL_INFO_VERSION_PLACEHOLDER|_agent6|' \
+		-e 's|IS_LEGACY_SCRIPT_PLACEHOLDER||' \
 		-e 's|DEPRECATION_MESSAGE_PLACEHOLDER||' \
 		install_script.sh.template > $@
 	chmod +x $@
@@ -32,6 +34,7 @@ install_script_agent7.sh: install_script.sh.template
 	sed -e 's|AGENT_MAJOR_VERSION_PLACEHOLDER|7|' \
 		-e 's|INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER| 7|' \
 		-e 's|INSTALL_INFO_VERSION_PLACEHOLDER|_agent7|' \
+		-e 's|IS_LEGACY_SCRIPT_PLACEHOLDER||' \
 		-e 's|DEPRECATION_MESSAGE_PLACEHOLDER||' \
 		install_script.sh.template > $@
 	chmod +x $@

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -257,7 +257,7 @@ if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
     exit 1;
   fi
   agent_major_version=$DD_AGENT_MAJOR_VERSION
-else
+elif [ "IS_LEGACY_SCRIPT_PLACEHOLDER" == "true" ]; then
   if [ "$agent_flavor" == "datadog-agent" ] ; then
     echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing $nice_flavor version 6 by default.\033[0m"
   else

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -1,10 +1,15 @@
 #!/bin/bash -e
 
+EXPECTED_FLAVOR=${DD_AGENT_FLAVOR:-datadog-agent}
+if [ "${EXPECTED_FLAVOR}" != "datadog-agent" ] && echo "${SCRIPT}" | grep "agent6.sh$" >/dev/null; then
+    echo "[PASS] Can't install flavor '${DD_AGENT_FLAVOR}' with install_script_agent6.sh"
+    exit 0
+fi
+
 $SCRIPT
 
 INSTALLED_VERSION=
 RESULT=0
-EXPECTED_FLAVOR=${DD_AGENT_FLAVOR:-datadog-agent}
 EXPECTED_MAJOR_VERSION=6
 if echo "${SCRIPT}" | grep "agent7.sh$" >/dev/null || [ "${EXPECTED_FLAVOR}" != "datadog-agent" ] ; then
     EXPECTED_MAJOR_VERSION=7


### PR DESCRIPTION
We don't want to show the warning on the versioned scripts, as they represent explicit version choice.

NOTE: This also means that installing IoT Agent or Dogstatsd will no longer be possible with `install_script_agent6.sh` (unless `DD_AGENT_MAJOR_VERSION=7` is specified explicitly), but I think that's ok.