### PR TITLE
Make datadog.yaml only readable by dd-agent

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -772,7 +772,7 @@ EOF
   fi
 fi
 
-$sudo_cmd chown dd-agent:dd-agent "$config_file"
+$sudo_cmd chown root:dd-agent "$config_file"
 $sudo_cmd chmod 640 "$config_file"
 
 # Creating or overriding the install information


### PR DESCRIPTION
This PR is a followup of this one https://github.com/DataDog/datadog-agent/pull/14078
which aims at restricting the configuration change the agent can do.
