### PR TITLE
Move from Debian 8 to Ubuntu 14 in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,12 +47,12 @@ test:
         FLAVOR: datadog-iot-agent
       - IMAGE: images/mirror/amazonlinux:2
       - IMAGE: images/mirror/amazonlinux:2022
-      - IMAGE: images/mirror/debian:8.11
-      - IMAGE: images/mirror/debian:8.11
+      - IMAGE: images/mirror/ubuntu:14.04
+      - IMAGE: images/mirror/ubuntu:14.04
         MINOR_VERSION: 38
-      - IMAGE: images/mirror/debian:8.11
+      - IMAGE: images/mirror/ubuntu:14.04
         FLAVOR: datadog-dogstatsd
-      - IMAGE: images/mirror/debian:8.11
+      - IMAGE: images/mirror/ubuntu:14.04
         FLAVOR: datadog-iot-agent
       - IMAGE: images/mirror/debian:10.9
       - IMAGE: images/mirror/debian:10.9


### PR DESCRIPTION
Debian 8 signing keys have expired, but Ubuntu 14 will still be maintained until April 2024. From our perspective these two systems are same.