### PR TITLE
Add success and failure telemetry events

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -960,8 +960,6 @@ if [ $no_start ]; then
   printf "\033[34m\n  * DD_INSTALL_ONLY environment variable set.\033[0m\n"
 fi
 
-# Metrics are submitted, echo some instructions and exit
-printf "\033[32m
 for current_service in "${services[@]}"; do
   nice_current_flavor=${flavor_to_readable[$current_service]}
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -127,6 +127,7 @@ END
     "$telemetry_url" \
     --header 'Content-Type: application/json' \
     --header "DD-Api-Key: $apikey" \
+    --header 'DD-Telemetry-Debug-Enabled: true' \
     --data @-
   then
     printf "Unable to send telemetry\n"
@@ -157,6 +158,11 @@ function get_email() {
 }
 
 function on_error() {
+    if [ -z "${ERROR_MESSAGE}" ] ; then
+      # Save the few lines of the log file for telemetry if the error message is blank
+      SAVED_ERROR_MESSAGE=$(tail -n 3 $logfile)
+    fi
+
     printf "\033[31m$ERROR_MESSAGE
 It looks like you hit an issue when trying to install the $nice_flavor.
 
@@ -164,6 +170,7 @@ Troubleshooting and basic usage information for the $nice_flavor are available a
 
     https://docs.datadoghq.com/agent/basic_agent_usage/\n\033[0m\n"
 
+    ERROR_MESSAGE=$SAVED_ERROR_MESSAGE
     ERROR_CODE=$GENERAL_ERROR_CODE
     report_telemetry
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -275,10 +275,9 @@ if [ -n "$DD_SITE" ]; then
     report_failure_url="https://api.${DD_SITE}/agent_stats/report_failure"
 fi
 
+telemetry_url="https://instrumentation-telemetry-intake.datadoghq.com/api/v2/apmtelemetry"
 if [ -n "$DD_SITE" ]; then
     telemetry_url="https://instrumentation-telemetry-intake.${DD_SITE}/api/v2/apmtelemetry"
-else
-    telemetry_url="https://instrumentation-telemetry-intake.datadoghq.com/api/v2/apmtelemetry"
 fi
 
 if [ -n "$TESTING_REPORT_URL" ]; then

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -32,6 +32,12 @@ RPM_GPG_KEYS=("DATADOG_RPM_KEY_CURRENT.public" "DATADOG_RPM_KEY_E09422B3.public"
 # DATADOG_RPM_KEY.public is only useful to install old (< 6.14) Agent packages.
 RPM_GPG_KEYS_A6=("DATADOG_RPM_KEY.public")
 
+# Error codes for telemetry
+GENERAL_ERROR_CODE=1
+UNSUPPORTED_PLATFORM_CODE=5
+INVALID_PARAMETERS_CODE=6
+UNABLE_TO_INSTALL_DEPENDENCY_CODE=7
+
 # Set up a named pipe for logging
 npipe=/tmp/$$.tmp
 mknod $npipe p
@@ -114,7 +120,7 @@ function report_telemetry() {
 "
   fi
 
-   (cat <<END
+  if ! (cat <<END
        $telemetry_event
 END
        ) | curl --fail --silent --output /dev/null \
@@ -122,7 +128,10 @@ END
     --header 'Content-Type: application/json' \
     --header "DD-Api-Key: $apikey" \
     --header 'DD-Telemetry-Debug-Enabled: true' \
-    --data @- || true
+    --data @-
+  then
+    printf "Unable to send telemetry\n"
+  fi
 }
 
 function on_read_error() {
@@ -156,7 +165,7 @@ Troubleshooting and basic usage information for the $nice_flavor are available a
 
     https://docs.datadoghq.com/agent/basic_agent_usage/\n\033[0m\n"
 
-    ERROR_CODE=1
+    ERROR_CODE=$GENERAL_ERROR_CODE
     report_telemetry
 
     if ! tty -s; then
@@ -194,7 +203,7 @@ function verify_agent_version(){
     local ver_separator="$1"
     if [ -z "$agent_version_custom" ]; then
         ERROR_MESSAGE="Specified version not found: $agent_major_version.$agent_minor_version"
-        ERROR_CODE=6
+        ERROR_CODE=$INVALID_PARAMETERS_CODE
         echo -e "
   \033[33mWarning: $ERROR_MESSAGE
   Check available versions at: https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst\033[0m"
@@ -311,7 +320,7 @@ nice_flavor=${flavor_to_readable[$agent_flavor]}
 
 if [ -z "$nice_flavor" ]; then
     ERROR_MESSAGE="Unknown DD_AGENT_FLAVOR \"$agent_flavor\""
-    ERROR_CODE=6
+    ERROR_CODE=$INVALID_PARAMETERS_CODE
     echo -e "\033[33m$ERROR_MESSAGE\033[0m"
     fallback_msg
     report_telemetry
@@ -342,7 +351,7 @@ agent_major_version=AGENT_MAJOR_VERSION_PLACEHOLDER
 if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
   if [ "$DD_AGENT_MAJOR_VERSION" != "6" ] && [ "$DD_AGENT_MAJOR_VERSION" != "7" ]; then
     ERROR_MESSAGE="DD_AGENT_MAJOR_VERSION must be either 6 or 7. Current value: $DD_AGENT_MAJOR_VERSION"
-    ERROR_CODE=6
+    ERROR_CODE=$INVALID_PARAMETERS_CODE
     echo "$ERROR_MESSAGE"
     report_telemetry
     exit 1;
@@ -372,14 +381,14 @@ if [ -n "$DD_AGENT_DIST_CHANNEL" ]; then
   if [ "$repository_url" == "datadoghq.com" ]; then
     if [ "$DD_AGENT_DIST_CHANNEL" != "stable" ] && [ "$DD_AGENT_DIST_CHANNEL" != "beta" ]; then
       ERROR_MESSAGE="DD_AGENT_DIST_CHANNEL must be either 'stable' or 'beta'. Current value: $DD_AGENT_DIST_CHANNEL"
-      ERROR_CODE=6
+      ERROR_CODE=$INVALID_PARAMETERS_CODE
       echo "$ERROR_MESSAGE"
       report_telemetry
       exit 1;
     fi
   elif [ "$DD_AGENT_DIST_CHANNEL" != "stable" ] && [ "$DD_AGENT_DIST_CHANNEL" != "beta" ] && [ "$DD_AGENT_DIST_CHANNEL" != "nightly" ]; then
     ERROR_MESSAGE="DD_AGENT_DIST_CHANNEL must be either 'stable', 'beta' or 'nightly' on custom repos. Current value: $DD_AGENT_DIST_CHANNEL"
-    ERROR_CODE=6
+    ERROR_CODE=$INVALID_PARAMETERS_CODE
     echo "$ERROR_MESSAGE"
     report_telemetry
     exit 1;
@@ -409,7 +418,7 @@ fi
 
 if [[ `uname -m` == "armv7l" ]] && [[ $agent_flavor == "datadog-agent" ]]; then
     ERROR_MESSAGE="The full $nice_flavor isn't available for your architecture (armv7l).\nInstall the ${flavor_to_readable[datadog-iot-agent]} by setting DD_AGENT_FLAVOR='datadog-iot-agent'."
-    ERROR_CODE=5
+    ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
     printf "\033[31m$ERROR_MESSAGE\033[0m\n"
     report_telemetry
     exit 1;
@@ -422,7 +431,7 @@ DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || gre
 
 if [ "$DISTRIBUTION" = "Darwin" ]; then
     ERROR_MESSAGE="This script does not support installing on the Mac."
-    ERROR_CODE=5
+    ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
     printf "\033[31m$ERROR_MESSAGE
 
 Please use the 1-step script available at https://app.datadoghq.com/account/settings#agent/mac.\033[0m\n"
@@ -447,14 +456,14 @@ fi
 if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
     if [[ `uname -m` == "armv7l" ]] || { [[ `uname -m` != "x86_64" ]] && [[ "$OS" != "Debian" ]]; }; then
         ERROR_MESSAGE="The $nice_flavor isn't available for your architecture."
-        ERROR_CODE=5
+        ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
         printf "\033[31m$ERROR_MESSAGE\033[0m\n"
         report_telemetry
         exit 1;
     fi
     if  [[ "$OS" == "Debian" ]] && [[ `uname -m` == "aarch64" ]] && { [[ -n "$agent_minor_version" ]] && [[ "$agent_minor_version" -lt 35 ]]; }; then
         ERROR_MESSAGE="The $nice_flavor is only available since version 7.35.0 for your architecture."
-        ERROR_CODE=5
+        ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
         printf "\033[31m$ERROR_MESSAGE\033[0m\n"
         report_telemetry
         exit 1;
@@ -472,7 +481,7 @@ fi
 if [ "$OS" = "RedHat" ]; then
     if { [ "$DISTRIBUTION" == "Rocky" ] || [ "$DISTRIBUTION" == "AlmaLinux" ]; } && { [ -n "$agent_minor_version" ] && [ "$agent_minor_version" -lt 33 ]; } && ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
         ERROR_MESSAGE="A future version of $nice_flavor will support $DISTRIBUTION"
-        ERROR_CODE=5
+        ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
         echo -e "\033[33m$ERROR_MESSAGE\n\033[0m"
         report_telemetry
         exit;
@@ -586,7 +595,7 @@ elif [ "$OS" = "Debian" ]; then
       if [ -n "$agent_minor_version_without_patch" ]; then
           if [ "$agent_minor_version_without_patch" -ge "36" ]; then
               ERROR_MESSAGE="Debian < 8 only supports $nice_flavor $agent_major_version up to $agent_major_version.35."
-              ERROR_CODE=5
+              ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
               printf "\033[31m$ERROR_MESSAGE\033[0m\n"
               report_telemetry
               exit;
@@ -636,7 +645,7 @@ elif [ "$OS" = "SUSE" ]; then
   UNAME_M=$(uname -m)
   if [ "$UNAME_M"  == "i686" ] || [ "$UNAME_M"  == "i386" ] || [ "$UNAME_M"  == "x86" ]; then
       ERROR_MESSAGE="The Datadog Agent installer is only available for 64 bit SUSE Enterprise machines."
-      ERROR_CODE=5
+      ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
       printf "\033[31m$ERROR_MESSAGE\033[0m\n"
       report_telemetry
       exit;
@@ -668,7 +677,7 @@ elif [ "$OS" = "SUSE" ]; then
     fi
     if ! rpm -q curl > /dev/null; then
       ERROR_MESSAGE="Failed to install curl."
-      ERROR_CODE=7
+      ERROR_CODE=$UNABLE_TO_INSTALL_DEPENDENCY_CODE
       echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
       fallback_msg
       report_telemetry
@@ -733,7 +742,7 @@ elif [ "$OS" = "SUSE" ]; then
       if [ -n "$agent_minor_version_without_patch" ]; then
           if [ "$agent_minor_version_without_patch" -ge "33" ]; then
               ERROR_MESSAGE="openSUSE < 15 only supports $nice_flavor $agent_major_version up to $agent_major_version.32."
-              ERROR_CODE=5
+              ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
               printf "\033[31m$ERROR_MESSAGE\033[0m\n"
               report_telemetry
               exit;
@@ -749,7 +758,7 @@ elif [ "$OS" = "SUSE" ]; then
       if [ -n "$agent_minor_version_without_patch" ]; then
           if [ "$agent_minor_version_without_patch" -ge "33" ]; then
               ERROR_MESSAGE="SLES < 12 only supports $nice_flavor $agent_major_version up to $agent_major_version.32."
-              ERROR_CODE=5
+              ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
               printf "\033[31m$ERROR_MESSAGE\033[0m\n"
               report_telemetry
               exit;
@@ -787,7 +796,7 @@ elif [ "$OS" = "SUSE" ]; then
   for expected_pkg in "${packages[@]}"; do
     if ! rpm -q "${expected_pkg}" > /dev/null; then
       ERROR_MESSAGE="Failed to install ${expected_pkg}."
-      ERROR_CODE=7
+      ERROR_CODE=$UNABLE_TO_INSTALL_DEPENDENCY_CODE
       echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
       fallback_msg
       report_telemetry
@@ -801,7 +810,7 @@ Please follow the instructions on the Agent setup page:
 
     https://app.datadoghq.com/account/settings#agent\033[0m\n"
     ERROR_MESSAGE="Unsupported platform"
-    ERROR_CODE=5
+    ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
     report_telemetry
     exit;
 fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -127,7 +127,6 @@ END
     "$telemetry_url" \
     --header 'Content-Type: application/json' \
     --header "DD-Api-Key: $apikey" \
-    --header 'DD-Telemetry-Debug-Enabled: true' \
     --data @-
   then
     printf "Unable to send telemetry\n"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -86,7 +86,8 @@ function report_telemetry() {
        \"event_name\": \"agent.installation.success\",
        \"tags\": {
            \"agent_platform\": \"native\",
-           \"agent_version\": \"$safe_agent_version\"
+           \"agent_version\": \"$safe_agent_version\",
+           \"script_version\": \"$install_script_version\"
        }
    }
 }
@@ -101,7 +102,8 @@ function report_telemetry() {
        \"event_name\": \"agent.installation.error\",
        \"tags\": {
            \"agent_platform\": \"native\",
-           \"agent_version\": \"$safe_agent_version\"
+           \"agent_version\": \"$safe_agent_version\",
+           \"script_version\": \"$install_script_version\"
        },
        \"error\": {
           \"code\": $ERROR_CODE,

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -63,6 +63,66 @@ function report(){
   fi
 }
 
+function report_telemetry() {
+  if [ "$DD_INSTRUMENTATION_TELEMETRY_ENABLED" == "false" ] || \
+    [ "$site" == "ddog-gov.com" ] || \
+    [ -z "${apikey}" ] || \
+    [ -z "$telemetry_url" ]; then
+    return
+  fi
+
+  if [ -n "$agent_minor_version" ] ; then
+    safe_agent_version=$(echo -n "$agent_major_version.$agent_minor_version" | tr '\n' ' ' | tr '"' '_')
+  else
+    safe_agent_version=$(echo -n "$agent_major_version" | tr '\n' ' ' | tr '"' '_')
+  fi
+
+  if [ -z "${ERROR_CODE}" ] ; then
+    telemetry_event="
+{
+   \"request_type\": \"apm-onboarding-event\",
+   \"api_version\": \"v1\",
+   \"payload\": {
+       \"event_name\": \"agent.installation.success\",
+       \"tags\": {
+           \"agent_platform\": \"native\",
+           \"agent_version\": \"$safe_agent_version\"
+       }
+   }
+}
+"
+  else
+    safe_error_message=$(echo -n "$ERROR_MESSAGE" | tr '\n' ' ' | tr '"' '_')
+    telemetry_event="
+{
+   \"request_type\": \"apm-onboarding-event\",
+   \"api_version\": \"v1\",
+   \"payload\": {
+       \"event_name\": \"agent.installation.error\",
+       \"tags\": {
+           \"agent_platform\": \"native\",
+           \"agent_version\": \"$safe_agent_version\"
+       },
+       \"error\": {
+          \"code\": $ERROR_CODE,
+          \"message\": \"$safe_error_message\"
+       }
+   }
+}
+"
+  fi
+
+   (cat <<END
+       $telemetry_event
+END
+       ) | curl --fail --verbose --output /dev/null \
+    "$telemetry_url" \
+    --header 'Content-Type: application/json' \
+    --header "DD-Api-Key: $apikey" \
+    --header 'DD-Telemetry-Debug-Enabled: true' \
+    --data @- || true
+}
+
 function on_read_error() {
   printf "Timed out or input EOF reached, assuming 'No'\n"
   yn="n"
@@ -93,6 +153,9 @@ It looks like you hit an issue when trying to install the $nice_flavor.
 Troubleshooting and basic usage information for the $nice_flavor are available at:
 
     https://docs.datadoghq.com/agent/basic_agent_usage/\n\033[0m\n"
+
+    ERROR_CODE=1
+    report_telemetry
 
     if ! tty -s; then
       fallback_msg
@@ -128,10 +191,13 @@ trap on_error ERR
 function verify_agent_version(){
     local ver_separator="$1"
     if [ -z "$agent_version_custom" ]; then
+        ERROR_MESSAGE="Specified version not found: $agent_major_version.$agent_minor_version"
+        ERROR_CODE=6
         echo -e "
-  \033[33mWarning: Specified version not found: $agent_major_version.$agent_minor_version
+  \033[33mWarning: $ERROR_MESSAGE
   Check available versions at: https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst\033[0m"
         fallback_msg
+        report_telemetry
         exit 1;
     else
         agent_flavor+="$ver_separator$agent_version_custom"
@@ -202,6 +268,22 @@ else
   apt_url="apt.${repository_url}"
 fi
 
+report_failure_url="https://api.datadoghq.com/agent_stats/report_failure"
+if [ -n "$DD_SITE" ]; then
+    report_failure_url="https://api.${DD_SITE}/agent_stats/report_failure"
+fi
+
+if [ -n "$DD_SITE" ]; then
+    telemetry_url="https://instrumentation-telemetry-intake.${DD_SITE}/api/v2/apmtelemetry"
+else
+    telemetry_url="https://instrumentation-telemetry-intake.datadoghq.com/api/v2/apmtelemetry"
+fi
+
+if [ -n "$TESTING_REPORT_URL" ]; then
+  report_failure_url=$TESTING_REPORT_URL
+  telemetry_url=$TESTING_REPORT_URL
+fi
+
 upgrade=
 if [ -n "$DD_UPGRADE" ]; then
   upgrade=$DD_UPGRADE
@@ -227,8 +309,11 @@ flavor_to_readable=(
 nice_flavor=${flavor_to_readable[$agent_flavor]}
 
 if [ -z "$nice_flavor" ]; then
-    echo -e "\033[33mUnknown DD_AGENT_FLAVOR \"$agent_flavor\"\033[0m"
+    ERROR_MESSAGE="Unknown DD_AGENT_FLAVOR \"$agent_flavor\""
+    ERROR_CODE=6
+    echo -e "\033[33m$ERROR_MESSAGE\033[0m"
     fallback_msg
+    report_telemetry
     exit 1;
 fi
 
@@ -255,7 +340,10 @@ agent_major_version=AGENT_MAJOR_VERSION_PLACEHOLDER
 # ^ to disable the warning about constant comparison in the elif clause below
 if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
   if [ "$DD_AGENT_MAJOR_VERSION" != "6" ] && [ "$DD_AGENT_MAJOR_VERSION" != "7" ]; then
-    echo "DD_AGENT_MAJOR_VERSION must be either 6 or 7. Current value: $DD_AGENT_MAJOR_VERSION"
+    ERROR_MESSAGE="DD_AGENT_MAJOR_VERSION must be either 6 or 7. Current value: $DD_AGENT_MAJOR_VERSION"
+    ERROR_CODE=6
+    echo "$ERROR_MESSAGE"
+    report_telemetry
     exit 1;
   fi
   agent_major_version=$DD_AGENT_MAJOR_VERSION
@@ -282,11 +370,17 @@ agent_dist_channel=stable
 if [ -n "$DD_AGENT_DIST_CHANNEL" ]; then
   if [ "$repository_url" == "datadoghq.com" ]; then
     if [ "$DD_AGENT_DIST_CHANNEL" != "stable" ] && [ "$DD_AGENT_DIST_CHANNEL" != "beta" ]; then
-      echo "DD_AGENT_DIST_CHANNEL must be either 'stable' or 'beta'. Current value: $DD_AGENT_DIST_CHANNEL"
+      ERROR_MESSAGE="DD_AGENT_DIST_CHANNEL must be either 'stable' or 'beta'. Current value: $DD_AGENT_DIST_CHANNEL"
+      ERROR_CODE=6
+      echo "$ERROR_MESSAGE"
+      report_telemetry
       exit 1;
     fi
   elif [ "$DD_AGENT_DIST_CHANNEL" != "stable" ] && [ "$DD_AGENT_DIST_CHANNEL" != "beta" ] && [ "$DD_AGENT_DIST_CHANNEL" != "nightly" ]; then
-    echo "DD_AGENT_DIST_CHANNEL must be either 'stable', 'beta' or 'nightly' on custom repos. Current value: $DD_AGENT_DIST_CHANNEL"
+    ERROR_MESSAGE="DD_AGENT_DIST_CHANNEL must be either 'stable', 'beta' or 'nightly' on custom repos. Current value: $DD_AGENT_DIST_CHANNEL"
+    ERROR_CODE=6
+    echo "$ERROR_MESSAGE"
+    report_telemetry
     exit 1;
   fi
   agent_dist_channel=$DD_AGENT_DIST_CHANNEL
@@ -304,14 +398,6 @@ else
   apt_repo_version="${agent_dist_channel} ${agent_major_version}"
 fi
 
-report_failure_url="https://api.datadoghq.com/agent_stats/report_failure"
-if [ -n "$DD_SITE" ]; then
-    report_failure_url="https://api.${DD_SITE}/agent_stats/report_failure"
-fi
-if [ -n "$TESTING_REPORT_URL" ]; then
-  report_failure_url=$TESTING_REPORT_URL
-fi
-
 if [ ! "$apikey" ]; then
   # if it's an upgrade, then we will use the transition script
   if [ ! "$upgrade" ] && [ ! -e "$config_file" ]; then
@@ -321,7 +407,10 @@ if [ ! "$apikey" ]; then
 fi
 
 if [[ `uname -m` == "armv7l" ]] && [[ $agent_flavor == "datadog-agent" ]]; then
-    printf "\033[31mThe full $nice_flavor isn't available for your architecture (armv7l).\nInstall the ${flavor_to_readable[datadog-iot-agent]} by setting DD_AGENT_FLAVOR='datadog-iot-agent'.\033[0m\n"
+    ERROR_MESSAGE="The full $nice_flavor isn't available for your architecture (armv7l).\nInstall the ${flavor_to_readable[datadog-iot-agent]} by setting DD_AGENT_FLAVOR='datadog-iot-agent'."
+    ERROR_CODE=5
+    printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+    report_telemetry
     exit 1;
 fi
 
@@ -331,9 +420,12 @@ KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE|Roc
 DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || grep -m1 -Eo $KNOWN_DISTRIBUTION /etc/os-release 2>/dev/null || uname -s)
 
 if [ "$DISTRIBUTION" = "Darwin" ]; then
-    printf "\033[31mThis script does not support installing on the Mac.
+    ERROR_MESSAGE="This script does not support installing on the Mac."
+    ERROR_CODE=5
+    printf "\033[31m$ERROR_MESSAGE
 
 Please use the 1-step script available at https://app.datadoghq.com/account/settings#agent/mac.\033[0m\n"
+    report_telemetry
     exit 1;
 
 elif [ -f /etc/debian_version ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
@@ -353,11 +445,17 @@ fi
 
 if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
     if [[ `uname -m` == "armv7l" ]] || { [[ `uname -m` != "x86_64" ]] && [[ "$OS" != "Debian" ]]; }; then
-        printf "\033[31mThe $nice_flavor isn't available for your architecture.\033[0m\n"
+        ERROR_MESSAGE="The $nice_flavor isn't available for your architecture."
+        ERROR_CODE=5
+        printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+        report_telemetry
         exit 1;
     fi
     if  [[ "$OS" == "Debian" ]] && [[ `uname -m` == "aarch64" ]] && { [[ -n "$agent_minor_version" ]] && [[ "$agent_minor_version" -lt 35 ]]; }; then
-        printf "\033[31mThe $nice_flavor is only available since version 7.35.0 for your architecture.\033[0m\n"
+        ERROR_MESSAGE="The $nice_flavor is only available since version 7.35.0 for your architecture."
+        ERROR_CODE=5
+        printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+        report_telemetry
         exit 1;
     fi
 fi
@@ -372,7 +470,10 @@ fi
 # Install the necessary package sources
 if [ "$OS" = "RedHat" ]; then
     if { [ "$DISTRIBUTION" == "Rocky" ] || [ "$DISTRIBUTION" == "AlmaLinux" ]; } && { [ -n "$agent_minor_version" ] && [ "$agent_minor_version" -lt 33 ]; } && ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
-        echo -e "\033[33mA future version of $nice_flavor will support $DISTRIBUTION\n\033[0m"
+        ERROR_MESSAGE="A future version of $nice_flavor will support $DISTRIBUTION"
+        ERROR_CODE=5
+        echo -e "\033[33m$ERROR_MESSAGE\n\033[0m"
+        report_telemetry
         exit;
     fi
     echo -e "\033[34m\n* Installing YUM sources for Datadog\n\033[0m"
@@ -483,7 +584,10 @@ elif [ "$OS" = "Debian" ]; then
     if [ "$DISTRIBUTION" == "Debian" ] && [ "$release_version" -lt 8 ]; then
       if [ -n "$agent_minor_version_without_patch" ]; then
           if [ "$agent_minor_version_without_patch" -ge "36" ]; then
-              printf "\033[31mDebian < 8 only supports $nice_flavor %s up to %s.35.\033[0m\n" "$agent_major_version" "$agent_major_version"
+              ERROR_MESSAGE="Debian < 8 only supports $nice_flavor $agent_major_version up to $agent_major_version.35."
+              ERROR_CODE=5
+              printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+              report_telemetry
               exit;
           fi
       else
@@ -530,7 +634,10 @@ If the cause is unclear, please contact Datadog support.
 elif [ "$OS" = "SUSE" ]; then
   UNAME_M=$(uname -m)
   if [ "$UNAME_M"  == "i686" ] || [ "$UNAME_M"  == "i386" ] || [ "$UNAME_M"  == "x86" ]; then
-      printf "\033[31mThe Datadog Agent installer is only available for 64 bit SUSE Enterprise machines.\033[0m\n"
+      ERROR_MESSAGE="The Datadog Agent installer is only available for 64 bit SUSE Enterprise machines."
+      ERROR_CODE=5
+      printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+      report_telemetry
       exit;
   elif [ "$UNAME_M"  == "aarch64" ]; then
       ARCHI="aarch64"
@@ -559,8 +666,11 @@ elif [ "$OS" = "SUSE" ]; then
       $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install curl ||:
     fi
     if ! rpm -q curl > /dev/null; then
-      echo -e "\033[31mFailed to install curl.\033[0m\n"
+      ERROR_MESSAGE="Failed to install curl."
+      ERROR_CODE=7
+      echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
       fallback_msg
+      report_telemetry
       exit 1;
     fi
   fi
@@ -621,7 +731,10 @@ elif [ "$OS" = "SUSE" ]; then
   if [ "$DISTRIBUTION" == "openSUSE" ] && { [ "$SUSE11" == "yes" ] || [ "$SUSE_VER" -lt 15 ]; }; then
       if [ -n "$agent_minor_version_without_patch" ]; then
           if [ "$agent_minor_version_without_patch" -ge "33" ]; then
-              printf "\033[31mopenSUSE < 15 only supports $nice_flavor %s up to %s.32.\033[0m\n" "$agent_major_version" "$agent_major_version"
+              ERROR_MESSAGE="openSUSE < 15 only supports $nice_flavor $agent_major_version up to $agent_major_version.32."
+              ERROR_CODE=5
+              printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+              report_telemetry
               exit;
           fi
       else
@@ -634,7 +747,10 @@ elif [ "$OS" = "SUSE" ]; then
   if [ "$DISTRIBUTION" == "SUSE" ] && { [ "$SUSE11" == "yes" ] || [ "$SUSE_VER" -lt 12 ]; }; then
       if [ -n "$agent_minor_version_without_patch" ]; then
           if [ "$agent_minor_version_without_patch" -ge "33" ]; then
-              printf "\033[31mSLES < 12 only supports $nice_flavor %s up to %s.32.\033[0m\n" "$agent_major_version" "$agent_major_version"
+              ERROR_MESSAGE="SLES < 12 only supports $nice_flavor $agent_major_version up to $agent_major_version.32."
+              ERROR_CODE=5
+              printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+              report_telemetry
               exit;
           fi
       else
@@ -669,8 +785,11 @@ elif [ "$OS" = "SUSE" ]; then
   # anyway. Therefore we let it do its thing and then see if curl was installed or not.
   for expected_pkg in "${packages[@]}"; do
     if ! rpm -q "${expected_pkg}" > /dev/null; then
-      echo -e "\033[31mFailed to install ${expected_pkg}.\033[0m\n"
+      ERROR_MESSAGE="Failed to install ${expected_pkg}."
+      ERROR_CODE=7
+      echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
       fallback_msg
+      report_telemetry
       exit 1;
     fi
   done
@@ -680,6 +799,9 @@ else
 Please follow the instructions on the Agent setup page:
 
     https://app.datadoghq.com/account/settings#agent\033[0m\n"
+    ERROR_MESSAGE="Unsupported platform"
+    ERROR_CODE=5
+    report_telemetry
     exit;
 fi
 
@@ -820,12 +942,16 @@ following command:
     $start_instructions
 
 \033[0m\n"
+    report_telemetry
     exit
 fi
 
 printf "\033[34m* Starting the $nice_flavor...\n\033[0m\n"
+ERROR_MESSAGE="Error starting service"
+
 eval "$restart_cmd"
 
+ERROR_MESSAGE=""
 
 # Metrics are submitted, echo some instructions and exit
 printf "\033[32m
@@ -842,3 +968,5 @@ And to run it again run:
     $start_instructions
 
 \033[0m"
+
+report_telemetry

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -804,12 +804,12 @@ elif [ "$OS" = "SUSE" ]; then
   done
 
 else
-    printf "\033[31mYour OS or distribution are not supported by this install script.
+    ERROR_MESSAGE="Your OS or distribution are not supported by this install script.
 Please follow the instructions on the Agent setup page:
 
-    https://app.datadoghq.com/account/settings#agent\033[0m\n"
-    ERROR_MESSAGE="Unsupported platform"
+https://app.datadoghq.com/account/settings#agent"
     ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
+    printf "\033[31m$ERROR_MESSAGE\033[0m\n"
     report_telemetry
     exit;
 fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -117,7 +117,7 @@ function report_telemetry() {
    (cat <<END
        $telemetry_event
 END
-       ) | curl --fail --verbose --output /dev/null \
+       ) | curl --fail --silent --output /dev/null \
     "$telemetry_url" \
     --header 'Content-Type: application/json' \
     --header "DD-Api-Key: $apikey" \


### PR DESCRIPTION
This PR add success and failure telemetry events for agent installation. There are 3 main changes:

1.  The `report_telemetry()` function that sends telemetry to the backend
2. Calling `report_telemetry()` in every case there was an `exit`. This consists of:
     a. Setting `ERROR_MESSAGE`
     b. Setting `ERROR_CODE`
     c. Printing the message to the screen
     d. Reporting telemetry
3. Setting `report_failure_url` and `telemetry_url` was moved to earlier in the script to catch more potential errors.

### Testing
It was not possible to test every scenario, but I manually tested the following using the production telemetry intake:
* Successful install
* Successful upgrade
* Failure because of unknown minor revision (set via environment variable)
* Failure because of unknown flavor (set via environment variable)
* Failure because of unknown distribution channel (set via environment variable)
* Failure because of unsupported platform (mac)
* Setting `DD_INSTRUMENTATION_TELEMETRY_ENABLED=false` disables telemetry
