### PR TITLE
[template] fips-proxy package updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 
 variables:
   DATADOG_AGENT_BUILDERS: v9930706-ef9d493
-  DATADOG_AGENT_BUILDIMAGES: v9910873-5790982
+  DATADOG_AGENT_BUILDIMAGES: v11651098-faf0544
   S3_CP_CMD: aws s3 cp --only-show-errors --region us-east-1 --sse AES256
 
 generate-scripts:

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -832,10 +832,11 @@ fi
 declare -a monitoring_services
 monitoring_services=( "datadog-agent" )
 
-printf "\033[34m\n  * DD_INSTALL_ONLY environment variable set.\033[0m\n"
+if [ $no_start ]; then
+  printf "\033[34m\n  * DD_INSTALL_ONLY environment variable set.\033[0m\n"
+fi
 
 for current_service in "${services[@]}"; do
-
   nice_current_flavor=${flavor_to_readable[$current_service]}
 
   # Use /usr/sbin/service by default.
@@ -872,7 +873,7 @@ for current_service in "${services[@]}"; do
   # Metrics are submitted, echo some instructions and exit
   printf "\033[32m  Your ${nice_current_flavor} is running and functioning properly.\n\033[0m"
 
-  if [[  " ${monitoring_services[*]} ~= " ${current_service} "  ]]; then
+  if [[ "${monitoring_services[*]}" =~ "${current_service}" ]]; then
     printf "\033[32m  It will continue to run in the background and submit metrics to Datadog.\n\033[0m"
   fi
   

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -237,18 +237,21 @@ flavor_to_system_service=(
     ["datadog-dogstatsd"]="datadog-dogstatsd"
 )
 system_service=${flavor_to_system_service[$agent_flavor]:-datadog-agent}
+system_fips_service=datadog-fips-proxy
 
 declare -A flavor_to_etcdir
 flavor_to_etcdir=(
     ["datadog-dogstatsd"]="/etc/datadog-dogstatsd"
 )
 etcdir=${flavor_to_etcdir[$agent_flavor]:-/etc/datadog-agent}
+etcdirfips=/etc/datadog-fips-proxy
 
 declare -A flavor_to_config
 flavor_to_config=(
     ["datadog-dogstatsd"]="$etcdir/dogstatsd.yaml"
 )
 config_file=${flavor_to_config[$agent_flavor]:-$etcdir/datadog.yaml}
+config_file_fips=$etcdirfips/datadog-fips-proxy.cfg
 
 agent_major_version=AGENT_MAJOR_VERSION_PLACEHOLDER
 # shellcheck disable=SC2050
@@ -434,13 +437,12 @@ if [ "$OS" = "RedHat" ]; then
     fi
     echo -e "  \033[33mInstalling package: $agent_flavor\n\033[0m"
 
-    declare -a packages
-    packages=("$agent_flavor")
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "$agent_flavor" || $sudo_cmd yum -y install $dnf_flag "$agent_flavor"
+    # sequence matters, hence why datadog-fips-proxy must be installed
+    # separately in a second step
     if [ -n "$fips_mode" ]; then
-      packages+=("datadog-fips-proxy")
+      $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "datadog-fips-proxy" || $sudo_cmd yum -y install $dnf_flag "datadog-fips-proxy"
     fi
-
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}"
 
 elif [ "$OS" = "Debian" ]; then
     apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
@@ -519,13 +521,14 @@ If the cause is unclear, please contact Datadog support.
     fi
     echo -e "  \033[33mInstalling package: $agent_flavor\n\033[0m"
 
-    declare -a packages
-    packages=("$agent_flavor" "datadog-signing-keys")
+
+    $sudo_cmd apt-get install -y --force-yes "${agent_flavor}"
+    # sequence matters, hence why datadog-fips-proxy must be installed
+    # separately in a second step
     if [ -n "$fips_mode" ]; then
-     packages+=("datadog-fips-proxy")
+      $sudo_cmd apt-get install -y --force-yes "datadog-fips-proxy"
     fi
 
-    $sudo_cmd apt-get install -y --force-yes "${packages[@]}"
     ERROR_MESSAGE=""
 elif [ "$OS" = "SUSE" ]; then
   UNAME_M=$(uname -m)
@@ -653,16 +656,21 @@ elif [ "$OS" = "SUSE" ]; then
   fi
   echo -e "  \033[33mInstalling package: $agent_flavor\n\033[0m"
 
-  declare -a packages
-  packages=("$agent_flavor")
-  if [ -n "$fips_mode" ]; then
-    packages+=("datadog-fips-proxy")
-  fi
 
   if [ -z "$sudo_cmd" ]; then
     ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" ||:
+    # sequence matters, hence why datadog-fips-proxy must be installed
+    # separately in a second step
+    if [ -n "$fips_mode" ]; then
+      ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "datadog-fips-proxy" ||:
+    fi
   else
     $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" ||:
+    # sequence matters, hence why datadog-fips-proxy must be installed
+    # separately in a second step
+    if [ -n "$fips_mode" ]; then
+      $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "datadog-fips-proxy" ||:
+    fi
   fi
 
   # If zypper fails to refresh a random repo, it installs the package, but then fails
@@ -775,6 +783,23 @@ fi
 $sudo_cmd chown dd-agent:dd-agent "$config_file"
 $sudo_cmd chmod 640 "$config_file"
 
+# set the FIPS configuration
+if [ -n "$fips_mode" ]; then
+  if [ -e "$config_file_fips" ] && [ -z "$upgrade" ]; then
+    printf "\033[34m\n* Keeping old $config_file_fips configuration file\n\033[0m\n"
+  else
+    if [ ! -e "$config_file_fips" ]; then
+      $sudo_cmd cp "$config_file_fips.example" "$config_file_fips"
+  
+      # TODO: set port range in file, or environment variable
+    fi
+
+    $sudo_cmd chown dd-agent:dd-agent "$config_file_fips"
+    $sudo_cmd chmod 640 "$config_file_fips"
+
+  fi
+fi
+
 # Creating or overriding the install information
 install_info_content="---
 install_method:
@@ -783,6 +808,11 @@ install_method:
   installer_version: install_script-$install_script_version
 "
 $sudo_cmd sh -c "echo '$install_info_content' > $etcdir/install_info"
+
+if [ -n "$fips_mode" ]; then
+  # Creating or overriding the install information
+  $sudo_cmd sh -c "echo '$install_info_content' > $etcdirfips/install_info"
+fi
 
 # On SUSE 11, sudo service datadog-agent start fails (because /sbin is not in a base user's path)
 # However, sudo /sbin/service datadog-agent does work.
@@ -798,17 +828,26 @@ fi
 restart_cmd="$sudo_cmd $service_cmd $system_service restart"
 stop_instructions="$sudo_cmd $service_cmd $system_service stop"
 start_instructions="$sudo_cmd $service_cmd $system_service start"
+restart_fips_cmd="$sudo_cmd $service_cmd $system_fips_service restart"
+stop_fips_instructions="$sudo_cmd $service_cmd $system_fips_service stop"
+start_fips_instructions="$sudo_cmd $service_cmd $system_fips_service start"
 
 if [[ `$sudo_cmd ps --no-headers -o comm 1 2>&1` == "systemd" ]] && command -v systemctl 2>&1; then
   # Use systemd if systemctl binary exists and systemd is the init process
   restart_cmd="$sudo_cmd systemctl restart ${system_service}.service"
   stop_instructions="$sudo_cmd systemctl stop $system_service"
   start_instructions="$sudo_cmd systemctl start $system_service"
+  restart_fips_cmd="$sudo_cmd systemctl restart ${system_fips_service}.service"
+  stop_fips_instructions="$sudo_cmd systemctl stop $system_fips_service"
+  start_fips_instructions="$sudo_cmd systemctl start $system_fips_service"
 elif /sbin/init --version 2>&1 | grep -q upstart; then
   # Try to detect Upstart, this works most of the times but still a best effort
   restart_cmd="$sudo_cmd stop $system_service || true ; sleep 2s ; $sudo_cmd start $system_service"
   stop_instructions="$sudo_cmd stop $system_service"
   start_instructions="$sudo_cmd start $system_service"
+  restart_fips_cmd="$sudo_cmd stop $system_fips_service || true ; sleep 2s ; $sudo_cmd start $system_fips_service"
+  stop_fips_instructions="$sudo_cmd stop $system_fips_service"
+  start_fips_instructions="$sudo_cmd start $system_fips_service"
 fi
 
 if [ $no_start ]; then
@@ -821,6 +860,11 @@ following command:
 
 \033[0m\n"
     exit
+fi
+
+if [ -n "$fips_mode" ]; then
+  printf "\033[34m* Starting the Datadog FIPS proxy...\n\033[0m\n"
+  eval "$restart_fips_cmd"
 fi
 
 printf "\033[34m* Starting the $nice_flavor...\n\033[0m\n"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -443,7 +443,7 @@ if [ "$OS" = "RedHat" ]; then
       packages+=("datadog-fips-proxy")
     fi
 
-    echo -e "  \033[33mInstalling package(s): ${packages[@]}\n\033[0m"
+    echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
     $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}"
 
@@ -529,7 +529,7 @@ If the cause is unclear, please contact Datadog support.
      packages+=("datadog-fips-proxy")
     fi
 
-    echo -e "  \033[33mInstalling package(s): ${packages[@]}\n\033[0m"
+    echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
     $sudo_cmd apt-get install -y --force-yes "${packages[@]}"
 
@@ -666,7 +666,7 @@ elif [ "$OS" = "SUSE" ]; then
   fi
 
 
-  echo -e "  \033[33mInstalling package(s): ${packages[@]}\n\033[0m"
+  echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
   if [ -z "$sudo_cmd" ]; then
     ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" ||:

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -873,7 +873,7 @@ for current_service in "${services[@]}"; do
   # Metrics are submitted, echo some instructions and exit
   printf "\033[32m  Your ${nice_current_flavor} is running and functioning properly.\n\033[0m"
 
-  if [[ "${monitoring_services[*]}" =~ "${current_service}" ]]; then
+  if [[ "${monitoring_services[*]}" =~ ${current_service} ]]; then
     printf "\033[32m  It will continue to run in the background and submit metrics to Datadog.\n\033[0m"
   fi
   

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -222,6 +222,7 @@ flavor_to_readable=(
     ["datadog-agent"]="Datadog Agent"
     ["datadog-iot-agent"]="Datadog IoT Agent"
     ["datadog-dogstatsd"]="Datadog Dogstatsd"
+    ["datadog-fips-proxy"]="Datadog FIPS Proxy"
     ["datadog-heroku-agent"]="Datadog Heroku Agent"
 )
 nice_flavor=${flavor_to_readable[$agent_flavor]}
@@ -435,14 +436,16 @@ if [ "$OS" = "RedHat" ]; then
         agent_version_custom="$(yum -y --disablerepo=* --enablerepo=datadog list --showduplicates datadog-agent | sort -r | grep -E "$pkg_pattern" -om1)" || true
         verify_agent_version "-"
     fi
-    echo -e "  \033[33mInstalling package: $agent_flavor\n\033[0m"
 
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "$agent_flavor" || $sudo_cmd yum -y install $dnf_flag "$agent_flavor"
-    # sequence matters, hence why datadog-fips-proxy must be installed
-    # separately in a second step
+    declare -a packages
+    packages=("$agent_flavor")
     if [ -n "$fips_mode" ]; then
-      $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "datadog-fips-proxy" || $sudo_cmd yum -y install $dnf_flag "datadog-fips-proxy"
+      packages+=("datadog-fips-proxy")
     fi
+
+    echo -e "  \033[33mInstalling package(s): ${packages[@]}\n\033[0m"
+
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}"
 
 elif [ "$OS" = "Debian" ]; then
     apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
@@ -519,15 +522,16 @@ If the cause is unclear, please contact Datadog support.
         agent_version_custom="$(apt-cache madison datadog-agent | grep -E "$pkg_pattern" -om1)" || true
         verify_agent_version "="
     fi
-    echo -e "  \033[33mInstalling package: $agent_flavor\n\033[0m"
 
-
-    $sudo_cmd apt-get install -y --force-yes "${agent_flavor}"
-    # sequence matters, hence why datadog-fips-proxy must be installed
-    # separately in a second step
+    declare -a packages
+    packages=("$agent_flavor" "datadog-signing-keys")
     if [ -n "$fips_mode" ]; then
-      $sudo_cmd apt-get install -y --force-yes "datadog-fips-proxy"
+     packages+=("datadog-fips-proxy")
     fi
+
+    echo -e "  \033[33mInstalling package(s): ${packages[@]}\n\033[0m"
+
+    $sudo_cmd apt-get install -y --force-yes "${packages[@]}"
 
     ERROR_MESSAGE=""
 elif [ "$OS" = "SUSE" ]; then
@@ -654,27 +658,24 @@ elif [ "$OS" = "SUSE" ]; then
       agent_version_custom="$(zypper search -s datadog-agent | grep -E "$pkg_pattern" -om1)" || true
       verify_agent_version "-"
   fi
-  echo -e "  \033[33mInstalling package: $agent_flavor\n\033[0m"
 
+  declare -a packages
+  packages=("$agent_flavor")
+  if [ -n "$fips_mode" ]; then
+    packages+=("datadog-fips-proxy")
+  fi
+
+
+  echo -e "  \033[33mInstalling package(s): ${packages[@]}\n\033[0m"
 
   if [ -z "$sudo_cmd" ]; then
     ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" ||:
-    # sequence matters, hence why datadog-fips-proxy must be installed
-    # separately in a second step
-    if [ -n "$fips_mode" ]; then
-      ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "datadog-fips-proxy" ||:
-    fi
   else
     $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" ||:
-    # sequence matters, hence why datadog-fips-proxy must be installed
-    # separately in a second step
-    if [ -n "$fips_mode" ]; then
-      $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "datadog-fips-proxy" ||:
-    fi
   fi
 
   # If zypper fails to refresh a random repo, it installs the package, but then fails
-  # anyway. Therefore we let it do its thing and then see if curl was installed or not.
+  # anyway. Therefore we l-    declare -a packages
   for expected_pkg in "${packages[@]}"; do
     if ! rpm -q "${expected_pkg}" > /dev/null; then
       echo -e "\033[31mFailed to install ${expected_pkg}.\033[0m\n"
@@ -825,64 +826,58 @@ fi
 
 # Use /usr/sbin/service by default.
 # Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`
-restart_cmd="$sudo_cmd $service_cmd $system_service restart"
-stop_instructions="$sudo_cmd $service_cmd $system_service stop"
-start_instructions="$sudo_cmd $service_cmd $system_service start"
-restart_fips_cmd="$sudo_cmd $service_cmd $system_fips_service restart"
-stop_fips_instructions="$sudo_cmd $service_cmd $system_fips_service stop"
-start_fips_instructions="$sudo_cmd $service_cmd $system_fips_service start"
-
-if [[ `$sudo_cmd ps --no-headers -o comm 1 2>&1` == "systemd" ]] && command -v systemctl 2>&1; then
-  # Use systemd if systemctl binary exists and systemd is the init process
-  restart_cmd="$sudo_cmd systemctl restart ${system_service}.service"
-  stop_instructions="$sudo_cmd systemctl stop $system_service"
-  start_instructions="$sudo_cmd systemctl start $system_service"
-  restart_fips_cmd="$sudo_cmd systemctl restart ${system_fips_service}.service"
-  stop_fips_instructions="$sudo_cmd systemctl stop $system_fips_service"
-  start_fips_instructions="$sudo_cmd systemctl start $system_fips_service"
-elif /sbin/init --version 2>&1 | grep -q upstart; then
-  # Try to detect Upstart, this works most of the times but still a best effort
-  restart_cmd="$sudo_cmd stop $system_service || true ; sleep 2s ; $sudo_cmd start $system_service"
-  stop_instructions="$sudo_cmd stop $system_service"
-  start_instructions="$sudo_cmd start $system_service"
-  restart_fips_cmd="$sudo_cmd stop $system_fips_service || true ; sleep 2s ; $sudo_cmd start $system_fips_service"
-  stop_fips_instructions="$sudo_cmd stop $system_fips_service"
-  start_fips_instructions="$sudo_cmd start $system_fips_service"
-fi
-
-if [ $no_start ]; then
-    printf "\033[34m
-* DD_INSTALL_ONLY environment variable set: the newly installed version of the
-$nice_flavor will not be started. You will have to do it manually using the
-following command:
-
-    $start_instructions
-
-\033[0m\n"
-    exit
-fi
-
+#
+declare -a services
+services=("$system_service")
 if [ -n "$fips_mode" ]; then
-  printf "\033[34m* Starting the Datadog FIPS proxy...\n\033[0m\n"
-  eval "$restart_fips_cmd"
+  services+=("$system_fips_service")
 fi
 
-printf "\033[34m* Starting the $nice_flavor...\n\033[0m\n"
-eval "$restart_cmd"
+preamble="  * DD_INSTALL_ONLY environment variable set."
+for current_service in "${services[@]}"; do
+  restart_cmd="$sudo_cmd $service_cmd $current_service restart"
+  stop_instructions="$sudo_cmd $service_cmd $current_service stop"
+  start_instructions="$sudo_cmd $service_cmd $current_service start"
 
+  if [[ `$sudo_cmd ps --no-headers -o comm 1 2>&1` == "systemd" ]] && command -v systemctl 2>&1; then
+    # Use systemd if systemctl binary exists and systemd is the init process
+    restart_cmd="$sudo_cmd systemctl restart ${current_service}.service"
+    stop_instructions="$sudo_cmd systemctl stop $current_service"
+    start_instructions="$sudo_cmd systemctl start $current_service"
+  elif /sbin/init --version 2>&1 | grep -q upstart; then
+    # Try to detect Upstart, this works most of the times but still a best effort
+    restart_cmd="$sudo_cmd stop $current_service || true ; sleep 2s ; $sudo_cmd start $current_service"
+    stop_instructions="$sudo_cmd stop $current_service"
+    start_instructions="$sudo_cmd start $current_service"
+  fi
 
-# Metrics are submitted, echo some instructions and exit
-printf "\033[32m
+  if [ $no_start ]; then
+    printf "\033[34m\n${preamble}
+    The newly installed version of the ${flavor_to_readable[$current_service]} will not be started.
+    You will have to do it manually using the following command:
+  
+    $start_instructions\033[0m\n"
+  
+    exit
+  else
+    printf "\033[34m* Starting the ${flavor_to_readable[$current_service]}...\n\033[0m\n"
+    eval "$restart_cmd"
+    
+    
+    # Metrics are submitted, echo some instructions and exit
+    printf "\033[32m  Your ${flavor_to_readable[$current_service]} is running and functioning properly.\n\033[0m"
 
-Your $nice_flavor is running and functioning properly. It will continue
-to run in the background and submit metrics to Datadog.
-
-If you ever want to stop the $nice_flavor, run:
-
-    $stop_instructions
-
-And to run it again run:
-
-    $start_instructions
-
-\033[0m"
+    if [ ! -z "$preamble" ]; then
+      printf "\033[32m  It will continue to run in the background and submit metrics to Datadog.\n\033[0m"
+    fi
+    
+    printf "\033[32m  If you ever want to stop the ${flavor_to_readable[$current_service]}, run:
+    
+        $stop_instructions
+    
+  And to run it again run:
+    
+        $start_instructions\033[0m"
+  fi
+  preamble=
+done

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -238,7 +238,12 @@ flavor_to_system_service=(
     ["datadog-dogstatsd"]="datadog-dogstatsd"
 )
 system_service=${flavor_to_system_service[$agent_flavor]:-datadog-agent}
-system_fips_service=datadog-fips-proxy
+
+declare -a services
+services=("$system_service")
+if [ -n "$fips_mode" ]; then
+  services+=("datadog-fips-proxy")
+fi
 
 declare -A flavor_to_etcdir
 flavor_to_etcdir=(
@@ -675,7 +680,7 @@ elif [ "$OS" = "SUSE" ]; then
   fi
 
   # If zypper fails to refresh a random repo, it installs the package, but then fails
-  # anyway. Therefore we l-    declare -a packages
+  # anyway. Therefore we let it do its thing and then see if curl was installed or not.
   for expected_pkg in "${packages[@]}"; do
     if ! rpm -q "${expected_pkg}" > /dev/null; then
       echo -e "\033[31mFailed to install ${expected_pkg}.\033[0m\n"
@@ -824,17 +829,13 @@ if [ "$SUSE11" == "yes" ]; then
   service_cmd=`$sudo_cmd which service`
 fi
 
-# Use /usr/sbin/service by default.
-# Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`
-#
-declare -a services
-services=("$system_service")
-if [ -n "$fips_mode" ]; then
-  services+=("$system_fips_service")
-fi
-
 preamble="  * DD_INSTALL_ONLY environment variable set."
 for current_service in "${services[@]}"; do
+
+  nice_current_flavor=${flavor_to_readable[$current_service]}
+
+  # Use /usr/sbin/service by default.
+  # Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`
   restart_cmd="$sudo_cmd $service_cmd $current_service restart"
   stop_instructions="$sudo_cmd $service_cmd $current_service stop"
   start_instructions="$sudo_cmd $service_cmd $current_service start"
@@ -853,31 +854,31 @@ for current_service in "${services[@]}"; do
 
   if [ $no_start ]; then
     printf "\033[34m\n${preamble}
-    The newly installed version of the ${flavor_to_readable[$current_service]} will not be started.
+    The newly installed version of the ${nice_current_flavor} will not be started.
     You will have to do it manually using the following command:
   
     $start_instructions\033[0m\n"
   
-    exit
-  else
-    printf "\033[34m* Starting the ${flavor_to_readable[$current_service]}...\n\033[0m\n"
-    eval "$restart_cmd"
-    
-    
-    # Metrics are submitted, echo some instructions and exit
-    printf "\033[32m  Your ${flavor_to_readable[$current_service]} is running and functioning properly.\n\033[0m"
-
-    if [ ! -z "$preamble" ]; then
-      printf "\033[32m  It will continue to run in the background and submit metrics to Datadog.\n\033[0m"
-    fi
-    
-    printf "\033[32m  If you ever want to stop the ${flavor_to_readable[$current_service]}, run:
-    
-        $stop_instructions
-    
-  And to run it again run:
-    
-        $start_instructions\033[0m"
+    continue 
   fi
+
+  printf "\033[34m* Starting the ${nice_current_flavor}...\n\033[0m\n"
+  eval "$restart_cmd"
+    
+    
+  # Metrics are submitted, echo some instructions and exit
+  printf "\033[32m  Your ${nice_current_flavor} is running and functioning properly.\n\033[0m"
+
+  if [ ! -z "$preamble" ]; then
+    printf "\033[32m  It will continue to run in the background and submit metrics to Datadog.\n\033[0m"
+  fi
+  
+  printf "\033[32m  If you ever want to stop the ${nice_current_flavor}, run:
+  
+      $stop_instructions
+  
+And to run it again run:
+  
+      $start_instructions\033[0m"
   preamble=
 done

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -829,7 +829,11 @@ if [ "$SUSE11" == "yes" ]; then
   service_cmd=`$sudo_cmd which service`
 fi
 
-preamble="  * DD_INSTALL_ONLY environment variable set."
+declare -a monitoring_services
+monitoring_services=( "datadog-agent" )
+
+printf "\033[34m\n  * DD_INSTALL_ONLY environment variable set.\033[0m\n"
+
 for current_service in "${services[@]}"; do
 
   nice_current_flavor=${flavor_to_readable[$current_service]}
@@ -853,8 +857,7 @@ for current_service in "${services[@]}"; do
   fi
 
   if [ $no_start ]; then
-    printf "\033[34m\n${preamble}
-    The newly installed version of the ${nice_current_flavor} will not be started.
+    printf "\033[34m\n    The newly installed version of the ${nice_current_flavor} will not be started.
     You will have to do it manually using the following command:
   
     $start_instructions\033[0m\n"
@@ -869,7 +872,7 @@ for current_service in "${services[@]}"; do
   # Metrics are submitted, echo some instructions and exit
   printf "\033[32m  Your ${nice_current_flavor} is running and functioning properly.\n\033[0m"
 
-  if [ ! -z "$preamble" ]; then
+  if [[  " ${monitoring_services[*]} ~= " ${current_service} "  ]]; then
     printf "\033[32m  It will continue to run in the background and submit metrics to Datadog.\n\033[0m"
   fi
   
@@ -880,5 +883,4 @@ for current_service in "${services[@]}"; do
 And to run it again run:
   
       $start_instructions\033[0m"
-  preamble=
 done

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -861,7 +861,7 @@ for current_service in "${services[@]}"; do
     printf "\033[34m\n    The newly installed version of the ${nice_current_flavor} will not be started.
     You will have to do it manually using the following command:
   
-    $start_instructions\033[0m\n"
+    $start_instructions\033[0m\n\n"
   
     continue 
   fi
@@ -883,5 +883,5 @@ for current_service in "${services[@]}"; do
   
 And to run it again run:
   
-      $start_instructions\033[0m"
+      $start_instructions\033[0m\n\n"
 done

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -881,7 +881,7 @@ for current_service in "${services[@]}"; do
   
       $stop_instructions
   
-And to run it again run:
+  And to run it again run:
   
       $start_instructions\033[0m\n\n"
 done

--- a/test/dockertest.sh
+++ b/test/dockertest.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+PLATFORM="linux/amd64"
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     -s|--script)
@@ -17,6 +19,9 @@ while [[ $# -gt 0 ]]; do
     -f|--flavor)
       FLAVOR="$2"
       ;;
+    -p|--platform)
+      PLATFORM="$2"
+      ;;
     -*|--*)
       echo "Unknown option $1"
       exit 1
@@ -28,4 +33,4 @@ done
 [ -z "$SCRIPT" ] && echo "Please provide script file to test via -s/--script" && exit 1;
 [ -z "$IMAGE" ] && echo "Please provide image to test via -i/--image" && exit 1;
 
-docker run --rm -v $(pwd):/tmp/vol -e DD_INSTALL_ONLY=true -e DD_AGENT_MINOR_VERSION="${MINOR_VERSION}" -e DD_AGENT_FLAVOR="${FLAVOR}" -e EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION}" -e DD_API_KEY=123 -e SCRIPT="/tmp/vol/$SCRIPT" --entrypoint /tmp/vol/test/localtest.sh "$IMAGE"
+docker run --rm --platform $PLATFORM -v $(pwd):/tmp/vol -e DD_INSTALL_ONLY=true -e DD_AGENT_MINOR_VERSION="${MINOR_VERSION}" -e DD_AGENT_FLAVOR="${FLAVOR}" -e EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION}" -e DD_API_KEY=123 -e SCRIPT="/tmp/vol/$SCRIPT" --entrypoint /tmp/vol/test/localtest.sh "$IMAGE"


### PR DESCRIPTION
This PR adds a few changes to the script to better tackle the installation of the FIPS proxy. 

Specifically it improves a little bit the management of the FIPS proxy side of things, and also adds some config and service management steps to fully enable the services. 

It also addresses two minor issues:
- `dockertest.sh` script platform definition support
- updated buildimages tag