### PR TITLE
Use `fips` option instead of hardcoded *dd_url when DD_FIPS_MODE is set

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -496,6 +496,14 @@ if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
     fi
 fi
 
+if [ -n "fips_mode" ] && { [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch%.*}" -lt 41 ]]; }; then
+    ERROR_MESSAGE="FIPS mode is only available since version AGENT_MAJOR_VERSION_PLACEHOLDER.41.0 and requested minor version is $agent_minor_version"
+    ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
+    printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+    report_telemetry
+    exit 1;
+fi
+
 # Root user detection
 if [ "$(echo "$UID")" = "0" ]; then
     sudo_cmd=''
@@ -876,33 +884,10 @@ else
     $sudo_cmd sh -c "exec cat - '${config_file}.orig' > '$config_file'" <<EOF
 # Configuration for the agent to use datadog-fips-proxy to communicate with Datadog via FIPS-compliant channel.
 
-dd_url: http://localhost:9804
-
-apm_config:
-    apm_dd_url: http://localhost:9805
-    profiling_dd_url: http://localhost:9806
-    telemetry:
-        dd_url: http://localhost:9813
-
-process_config:
-    process_dd_url: http://localhost:9807
-
-logs_config:
-    use_http: true
-    logs_dd_url: localhost:9808
-    logs_no_ssl: true
-
-database_monitoring:
-    metrics:
-        dd_url: localhost:9809
-    activity:
-        dd_url: localhost:9809
-    samples:
-        dd_url: localhost:9810
-
-network_devices:
-    metadata:
-        dd_url: localhost:9811
+fips:
+    enabled: true
+    port_range_start: 9803
+    https: false
 EOF
   fi
   if [ "$hostname" ]; then

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -496,7 +496,7 @@ if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
     fi
 fi
 
-if [ -n "fips_mode" ] && { [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch%.*}" -lt 41 ]]; }; then
+if [ -n "$fips_mode" ] && { [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch%.*}" -lt 41 ]]; }; then
     ERROR_MESSAGE="FIPS mode is only available since version AGENT_MAJOR_VERSION_PLACEHOLDER.41.0 and requested minor version is $agent_minor_version"
     ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
     printf "\033[31m$ERROR_MESSAGE\033[0m\n"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -496,12 +496,21 @@ if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
     fi
 fi
 
-if [ -n "$fips_mode" ] && { [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch%.*}" -lt 41 ]]; }; then
-    ERROR_MESSAGE="FIPS mode is only available since version AGENT_MAJOR_VERSION_PLACEHOLDER.41.0 and requested minor version is $agent_minor_version"
-    ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
-    printf "\033[31m$ERROR_MESSAGE\033[0m\n"
-    report_telemetry
-    exit 1;
+if [ -n "$fips_mode" ]; then
+    if [[ `uname -m` != "x86_64" ]]; then
+        ERROR_MESSAGE="FIPS mode isn't available for your architecture"
+        ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
+        printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+        report_telemetry
+        exit 1;
+    fi
+    if [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch%.*}" -lt 41 ]]; then
+        ERROR_MESSAGE="FIPS mode is only available since version AGENT_MAJOR_VERSION_PLACEHOLDER.41.0 and requested minor version is $agent_minor_version"
+        ERROR_CODE=$INVALID_PARAMETERS_CODE
+        printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+        report_telemetry
+        exit 1;
+    fi
 fi
 
 # Root user detection


### PR DESCRIPTION
## Description

This PR does 2 things:

- It prevents from installing the FIPS proxy if the Agent minor version is lower than 41 or when the architecture is not x86_64
     - We do this because the `fips` option as been added in `7.41` and the FIPS proxy is not supported for versions older than 7.41
- It adds `fips` configuration into `datadog.yaml` instead of the bunch of `dd_url` options

## Questions

- I used `report_telemetry` to follow the pattern but I'm not really sure if this error is relevant for the instrumentation-telemetry team tbh (We don't except this error to be triggered a lot anyway)
-  Right now `ARM64` arch is not supported for FIPS proxy. The current error is 'no package was found' but should we add a more explicit message ? 
- `agent_minor_version_without_patch` value still contains patch information if `DD_AGENT_MINOR_VERSION` is set to an RC (e.g. `40.0~rc.1-1` becomes `40.0~rc`). I don't think it's important but it was triggering an error so I used `{agent_minor_version_without_patch%.*}`


## QA

#### Verify that version check is working
- Run `DD_API_KEY=<API_KEY> DD_SITE="datadoghq.com" DD_FIPS_MODE=1 DD_AGENT_MINOR_VERSION=40.0~rc.7-1 ./install_script.sh` (replace `./install_script` with the path to the tested script)
    - It should output `FIPS mode is only available since version 7.41.0 and requested minor version is 40.0~rc.7-1`

#### Verify that arch check is working

- On a non x86_64 host: run `DD_API_KEY=<API_KEY> DD_SITE="datadoghq.com" DD_FIPS_MODE=1 ./install_script.sh`
    - It should output `FIPS mode isn't available for your architecture`

#### Verify that `fips` option is set in `datadog.yaml`

- Run `DD_API_KEY=<API_KEY> DD_SITE="datadoghq.com" DD_FIPS_MODE=1 ./install_script.sh` (you might need to add `REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta` if packages are not deployed on prod yet)
     - Installation should run smoothly
     - Verify with ps (e.g. `ps aux | grep datadog`) that the Agent and the FIPS proxy are running
     - Run `datadog-agent diagnose datadog-connectivity` and verify that there is no error (expect for `/api/v1/validate` if you're not using a GovCloud API Key) + that the connection is going through `localhost:9804` (look at the command output)
     - Open `/etc/datadog-agent/datadog.yaml` and verify that the top lines are:
```
# Configuration for the agent to use datadog-fips-proxy to communicate with Datadog via FIPS-compliant channel.

fips:
    enabled: true
    port_range_start: 9803
    https: false
```
