### PR TITLE
Makefile targets to automate the release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,6 @@ install_script_agent7.sh: install_script.sh.template
 
 pre_release_%:
 	$(eval NEW_VERSION=$(shell echo "$@" | sed -e 's|pre_release_||'))
-	sed -i -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script.sh.template
-
+	sed -i "" -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script.sh.template
+	sed -i "" -e "s|^Unreleased|${NEW_VERSION}|g" CHANGELOG.rst
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ pre_release_minor:
 	sed -i "" -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script.sh.template
 	sed -i "" -e "s|^Unreleased|${NEW_VERSION}|g" CHANGELOG.rst
 
-post_release_%:
-	$(eval NEW_VERSION=$(shell echo "$@" | sed -e 's|post_release_||'))
-	sed -i "" -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}.post|g" install_script.sh.template
+post_release:
+	$(eval CUR_VERSION=$(shell awk -F "=" '/^install_script_version=/{print $$NF}' install_script.sh.template))
+	((echo ${CUR_VERSION} | grep ".post" &>/dev/null) || exit 0 && exit 1) || (echo "Invalid install script version (contain .post extension)" && exit 1)
+	sed -i "" -e "s|install_script_version=.*|install_script_version=${CUR_VERSION}.post|g" install_script.sh.template
 	echo "4i\n\nUnreleased\n================\n.\nw\nq" | ed CHANGELOG.rst

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,9 @@ install_script_agent7.sh: install_script.sh.template
 		-e 's|DEPRECATION_MESSAGE_PLACEHOLDER||' \
 		install_script.sh.template > $@
 	chmod +x $@
+
+pre_release_%:
+	$(eval NEW_VERSION=$(shell echo "$@" | sed -e 's|pre_release_||'))
+	sed -i -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script.sh.template
+
+

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,14 @@ pre_release_%:
 	sed -i "" -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script.sh.template
 	sed -i "" -e "s|^Unreleased|${NEW_VERSION}|g" CHANGELOG.rst
 
+pre_release_minor:
+	$(eval CUR_VERSION=$(shell awk -F "=" '/^install_script_version=/{print $$NF}' install_script.sh.template))
+	$(eval CUR_MINOR=$(shell echo "${CUR_VERSION}" | tr "." "\n" | awk 'NR==2'))
+	$(eval NEXT_MINOR=$(shell echo ${CUR_MINOR}+1 | bc))
+	$(eval NEW_VERSION=$(shell echo "${CUR_VERSION}" | awk -v repl="${NEXT_MINOR}" 'BEGIN {FS=OFS="."} {$$2=repl; print}' | sed -e 's|.post||'))
+	sed -i "" -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script.sh.template
+	sed -i "" -e "s|^Unreleased|${NEW_VERSION}|g" CHANGELOG.rst
+
 post_release_%:
 	$(eval NEW_VERSION=$(shell echo "$@" | sed -e 's|post_release_||'))
 	sed -i "" -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}.post|g" install_script.sh.template

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,7 @@ pre_release_%:
 	sed -i "" -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script.sh.template
 	sed -i "" -e "s|^Unreleased|${NEW_VERSION}|g" CHANGELOG.rst
 
+post_release_%:
+	$(eval NEW_VERSION=$(shell echo "$@" | sed -e 's|post_release_||'))
+	sed -i "" -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}.post|g" install_script.sh.template
+	echo "4i\n\nUnreleased\n================\n.\nw\nq" | ed CHANGELOG.rst


### PR DESCRIPTION
### Description

To automate the install script release process we need two new targets that :
 - Updates the changelog and bumps the version (before the release)
 - Updates the changelog again and adds the .post suffix to the version (after the release)

### Changes : 
- Added target pre_release_\<new-version\> : 
     -  Updates install_script_version=\<new-version\> in install_script.sh.template. It removes the .post as well
     - Updates the CHANGELOG.rst that renames the Unreleased version on top to \<new-version\>
- Added target post_release_\<new-version\>:
    - Updates install_script_version=\<new-version\> in install_script.sh.template to install_script_version=\<new-version\>.post (adding the .post at the end).
    - Updates the CHANGELOG.rst by adding a new Unreleased "version" on top of the file.