### PR TITLE
Fix pre-release handing

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -496,7 +496,7 @@ if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
         report_telemetry
         exit 1;
     fi
-    if  [[ "$OS" == "Debian" ]] && [[ `uname -m` == "aarch64" ]] && { [[ -n "$clean_agent_minor_version" ]] && [[ "$clean_agent_minor_version" -lt 35 ]]; }; then
+    if  [[ "$OS" == "Debian" ]] && [[ `uname -m` == "aarch64" ]] && { [[ -n "$agent_minor_version_without_patch" ]] && [[ "$agent_minor_version_without_patch" -lt 35 ]]; }; then
         ERROR_MESSAGE="The $nice_flavor is only available since version 7.35.0 for your architecture."
         ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
         printf "\033[31m$ERROR_MESSAGE\033[0m\n"
@@ -532,7 +532,7 @@ fi
 # Install the necessary package sources
 if [ "$OS" = "RedHat" ]; then
     remove_rpm_gpg_keys "$sudo_cmd" "${RPM_GPG_KEYS_TO_REMOVE[@]}"
-    if { [ "$DISTRIBUTION" == "Rocky" ] || [ "$DISTRIBUTION" == "AlmaLinux" ]; } && { [ -n "$clean_agent_minor_version" ] && [ "$clean_agent_minor_version" -lt 33 ]; } && ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
+    if { [ "$DISTRIBUTION" == "Rocky" ] || [ "$DISTRIBUTION" == "AlmaLinux" ]; } && { [ -n "$agent_minor_version_without_patch" ] && [ "$agent_minor_version_without_patch" -lt 33 ]; } && ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
         ERROR_MESSAGE="A future version of $nice_flavor will support $DISTRIBUTION"
         ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
         echo -e "\033[33m$ERROR_MESSAGE\n\033[0m"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -403,8 +403,9 @@ if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
   #  - 20   = defaults to highest patch version x.20.2
   #  - 20.0 = sets explicit patch version x.20.0
   # Note: Specifying an invalid minor version will terminate the script.
-  # Handle pre-release versions like "35.0~rc.5" -> "35.0" or "27.1~viper~conflict~fix" -> "27.1"
   agent_minor_version=${DD_AGENT_MINOR_VERSION}
+  # Handle pre-release versions like "35.0~rc.5" -> "35.0" or "27.1~viper~conflict~fix" -> "27.1"
+  # Allow to get a "clean" version number that can be used to compare the version with others (e.g: "35.0~rc.5" < "36.0" because "35.0" < "36.0")
   clean_agent_minor_version=$(echo "${DD_AGENT_MINOR_VERSION}" | sed -E 's/~.*//g')
   # remove the patch version if the minor version includes it (eg: 33.1 -> 33)
   agent_minor_version_without_patch="${clean_agent_minor_version%.*}"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -404,9 +404,10 @@ if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
   #  - 20.0 = sets explicit patch version x.20.0
   # Note: Specifying an invalid minor version will terminate the script.
   # Handle pre-release versions like "35.0~rc.5" -> "35.0" or "27.1~viper~conflict~fix" -> "27.1"
-  agent_minor_version=$(echo "${DD_AGENT_MINOR_VERSION}" | sed -E 's/~.*//g')
+  agent_minor_version=${DD_AGENT_MINOR_VERSION}
+  clean_agent_minor_version=$(echo "${DD_AGENT_MINOR_VERSION}" | sed -E 's/~.*//g')
   # remove the patch version if the minor version includes it (eg: 33.1 -> 33)
-  agent_minor_version_without_patch="${agent_minor_version%.*}"
+  agent_minor_version_without_patch="${clean_agent_minor_version%.*}"
 fi
 
 agent_dist_channel=stable
@@ -494,7 +495,7 @@ if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
         report_telemetry
         exit 1;
     fi
-    if  [[ "$OS" == "Debian" ]] && [[ `uname -m` == "aarch64" ]] && { [[ -n "$agent_minor_version" ]] && [[ "$agent_minor_version" -lt 35 ]]; }; then
+    if  [[ "$OS" == "Debian" ]] && [[ `uname -m` == "aarch64" ]] && { [[ -n "$clean_agent_minor_version" ]] && [[ "$clean_agent_minor_version" -lt 35 ]]; }; then
         ERROR_MESSAGE="The $nice_flavor is only available since version 7.35.0 for your architecture."
         ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
         printf "\033[31m$ERROR_MESSAGE\033[0m\n"
@@ -511,7 +512,7 @@ if [ -n "$fips_mode" ]; then
         report_telemetry
         exit 1;
     fi
-    if [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch%.*}" -lt 41 ]]; then
+    if [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch}" -lt 41 ]]; then
         ERROR_MESSAGE="FIPS mode is only available since version AGENT_MAJOR_VERSION_PLACEHOLDER.41.0 and requested minor version is $agent_minor_version"
         ERROR_CODE=$INVALID_PARAMETERS_CODE
         printf "\033[31m$ERROR_MESSAGE\033[0m\n"
@@ -530,7 +531,7 @@ fi
 # Install the necessary package sources
 if [ "$OS" = "RedHat" ]; then
     remove_rpm_gpg_keys "$sudo_cmd" "${RPM_GPG_KEYS_TO_REMOVE[@]}"
-    if { [ "$DISTRIBUTION" == "Rocky" ] || [ "$DISTRIBUTION" == "AlmaLinux" ]; } && { [ -n "$agent_minor_version" ] && [ "$agent_minor_version" -lt 33 ]; } && ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
+    if { [ "$DISTRIBUTION" == "Rocky" ] || [ "$DISTRIBUTION" == "AlmaLinux" ]; } && { [ -n "$clean_agent_minor_version" ] && [ "$clean_agent_minor_version" -lt 33 ]; } && ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
         ERROR_MESSAGE="A future version of $nice_flavor will support $DISTRIBUTION"
         ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
         echo -e "\033[33m$ERROR_MESSAGE\n\033[0m"
@@ -651,6 +652,7 @@ elif [ "$OS" = "Debian" ]; then
           if ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
               echo -e "  \033[33m$nice_flavor $agent_major_version.35 is the last supported version on $DISTRIBUTION $release_version. Installing $agent_major_version.35 now.\n\033[0m"
               agent_minor_version=35
+              clean_agent_minor_version=35
           fi
       fi
     fi
@@ -785,6 +787,7 @@ elif [ "$OS" = "SUSE" ]; then
           if ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
               echo -e "  \033[33m$nice_flavor $agent_major_version.32 is the last supported version on $DISTRIBUTION $SUSE_VER\n\033[0m"
               agent_minor_version=32
+              clean_agent_minor_version=32
           fi
       fi
   fi
@@ -801,6 +804,7 @@ elif [ "$OS" = "SUSE" ]; then
           if ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
               echo -e "  \033[33m$nice_flavor $agent_major_version.32 is the last supported version on $DISTRIBUTION $SUSE_VER\n\033[0m"
               agent_minor_version=32
+              clean_agent_minor_version=32
           fi
       fi
   fi


### PR DESCRIPTION
## Description
+ Previous implementation was making impossible to install a pre-release version. This should fix it and still parse pre-release correctly.

+ Fix on error handling that didn't worked on certain/older shell : 
```
agent_minor_version=19.0 
if [[ "$agent_minor_version" -lt 35 ]]; then
  echo ERROR
else
  echo OK
fi
```
  On classic recent shell we get
```
ERROR
```
  but on more basic shell like `sh` we get 
```
sh: [[: 19.0: syntax error: invalid arithmetic operator (error token is ".0")
OK
```
## Testing instructions
Test the script with : 
  - A release version ( e.g : 7.43.0 )
  - A pre-release version ( e.g : 7.15.1~beta.1 )
  - An error case ( e.g : datadog-dogstatsd 7.19.0~rc.7 on aarch64. Expected output : ``The Datadog Dogstatsd is only available since version 7.35.0 for your architecture.``)