### PR TITLE
[Fix] Ubuntu 14 false positive tests fix + dpkg-query upstream version equivalent

### DIFF
--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -33,8 +33,10 @@ echo -e "\n"
 MAJOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 1)
 MINOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 2)
 
+echo "${EXPECTED_MAJOR_VERSION}"
+echo "${MAJOR_VERSION}"
 
-if [ "${EXPECTED_MAJOR_VERSION}" -ne "${MAJOR_VERSION}" ]; then
+if [ "${EXPECTED_MAJOR_VERSION}" != "${MAJOR_VERSION}" ]; then
     echo "[FAIL] Expected major version ${EXPECTED_MAJOR_VERSION} to be installed, but found ${MAJOR_VERSION}"
     RESULT=1
 else
@@ -42,7 +44,7 @@ else
 fi
 
 if [ -n "${EXPECTED_MINOR_VERSION}" ]; then
-    if [ "${EXPECTED_MINOR_VERSION}" -ne "${MINOR_VERSION}" ]; then
+    if [ "${EXPECTED_MINOR_VERSION}" != "${MINOR_VERSION}" ]; then
         echo "[FAIL] Expected minor version ${EXPECTED_MINOR_VERSION} to be installed, but found ${MINOR_VERSION}"
         RESULT=1
     else

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -20,7 +20,7 @@ EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION:-${DD_AGENT_MINOR_VERSION}}"
 if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
-    INSTALLED_VERSION=$(dpkg-query -W ${EXPECTED_FLAVOR} | sed -E "s/[^\t]*\t//g")
+    INSTALLED_VERSION=$(dpkg-query -W ${EXPECTED_FLAVOR} | sed -E "s/[^\t]*\t//g" | sed -E "s/[0-9]+://g")
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -21,7 +21,7 @@ if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
-    echo "$INSTALLED_VERSION"
+    echo ">>>$INSTALLED_VERSION"
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -23,7 +23,7 @@ if command -v dpkg > /dev/null; then
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
     echo "===== DBG ====="
     echo "$(dpkg-query -f='${source:Upstream-Version}' -l | grep ${EXPECTED_FLAVOR})"
-    echo "$(dpkg-query -W ${EXPECTED_FLAVOR})"
+    echo "$(dpkg-query --version)"
     echo "==============="
 else
     # skip verification of mode/user/group, because these are

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -21,6 +21,7 @@ if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
+    echo $INSTALLED_VERSION"
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -21,7 +21,7 @@ if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
-    echo "$(dpkg-query -f='${source:Upstream-Version}' -l)"
+    echo "${EXPECTED_FLAVOR}"
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -22,8 +22,8 @@ if command -v dpkg > /dev/null; then
     debsums -c ${EXPECTED_FLAVOR}
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
     echo "===== DBG ====="
-    dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR}
     echo "$(dpkg-query -f='${source:Upstream-Version}' -l | grep ${EXPECTED_FLAVOR})"
+    echo "$(dpkg-query -W ${EXPECTED_FLAVOR})"
     echo "==============="
 else
     # skip verification of mode/user/group, because these are

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -21,7 +21,9 @@ if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
-    echo "${EXPECTED_FLAVOR}"
+    echo "$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})"
+    echo "$(dpkg-query -f='${source:Upstream-Version}' -l | grep ${EXPECTED_FLAVOR})"
+    echo $INSTALLED_VERSION
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -33,8 +33,8 @@ echo -e "\n"
 MAJOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 1)
 MINOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 2)
 
-echo "${EXPECTED_MAJOR_VERSION}"
-echo "${MAJOR_VERSION}"
+echo "${EXPECTED_MINOR_VERSION}"
+echo "${MINOR_VERSION}"
 
 if [ "${EXPECTED_MAJOR_VERSION}" != "${MAJOR_VERSION}" ]; then
     echo "[FAIL] Expected major version ${EXPECTED_MAJOR_VERSION} to be installed, but found ${MAJOR_VERSION}"

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -20,11 +20,7 @@ EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION:-${DD_AGENT_MINOR_VERSION}}"
 if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
-    INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
-    echo "===== DBG ====="
-    echo "$(dpkg-query -f='${source:Upstream-Version}' -l | grep ${EXPECTED_FLAVOR})"
-    echo "$(dpkg-query --version)"
-    echo "==============="
+    INSTALLED_VERSION=$(dpkg-query -W ${EXPECTED_FLAVOR} | sed -E "s/[^\t]*\t//g")
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -21,7 +21,7 @@ if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
-    echo $INSTALLED_VERSION"
+    echo "$INSTALLED_VERSION"
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -21,7 +21,7 @@ if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
-    echo ">>>$INSTALLED_VERSION"
+    echo ">>>$(dpkg-query -f='${source:Upstream-Version}')"
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -20,7 +20,7 @@ EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION:-${DD_AGENT_MINOR_VERSION}}"
 if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
-    INSTALLED_VERSION=$(dpkg-query -W ${EXPECTED_FLAVOR} | sed -E "s/[^\t]*\t//g" | sed -E "s/[0-9]+://g")
+    INSTALLED_VERSION=$(dpkg-query -W ${EXPECTED_FLAVOR} | cut -f2 | cut -d: -f2")
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -21,7 +21,7 @@ if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
-    echo ">>>$(dpkg-query -f='${source:Upstream-Version}')"
+    echo "$(dpkg-query -f='${source:Upstream-Version}' -l)"
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -33,10 +33,8 @@ echo -e "\n"
 MAJOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 1)
 MINOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 2)
 
-echo "${EXPECTED_MINOR_VERSION}"
-echo "${MINOR_VERSION}"
 
-if [ "${EXPECTED_MAJOR_VERSION}" != "${MAJOR_VERSION}" ]; then
+if [ "${EXPECTED_MAJOR_VERSION}" -ne "${MAJOR_VERSION}" ]; then
     echo "[FAIL] Expected major version ${EXPECTED_MAJOR_VERSION} to be installed, but found ${MAJOR_VERSION}"
     RESULT=1
 else
@@ -44,7 +42,7 @@ else
 fi
 
 if [ -n "${EXPECTED_MINOR_VERSION}" ]; then
-    if [ "${EXPECTED_MINOR_VERSION}" != "${MINOR_VERSION}" ]; then
+    if [ "${EXPECTED_MINOR_VERSION}" -ne "${MINOR_VERSION}" ]; then
         echo "[FAIL] Expected minor version ${EXPECTED_MINOR_VERSION} to be installed, but found ${MINOR_VERSION}"
         RESULT=1
     else

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -20,7 +20,7 @@ EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION:-${DD_AGENT_MINOR_VERSION}}"
 if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
-    INSTALLED_VERSION=$(dpkg-query -W ${EXPECTED_FLAVOR} | cut -f2 | cut -d: -f2")
+    INSTALLED_VERSION=$(dpkg-query -W ${EXPECTED_FLAVOR} | cut -f2 | cut -d: -f2)
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -21,9 +21,10 @@ if command -v dpkg > /dev/null; then
     apt-get install -y debsums
     debsums -c ${EXPECTED_FLAVOR}
     INSTALLED_VERSION=$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})
-    echo "$(dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR})"
+    echo "===== DBG ====="
+    dpkg-query -f='${source:Upstream-Version}' -W ${EXPECTED_FLAVOR}
     echo "$(dpkg-query -f='${source:Upstream-Version}' -l | grep ${EXPECTED_FLAVOR})"
-    echo $INSTALLED_VERSION
+    echo "==============="
 else
     # skip verification of mode/user/group, because these are
     # changed by the postinstall scriptlet

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -34,7 +34,7 @@ MAJOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 1)
 MINOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 2)
 
 
-if [ "${EXPECTED_MAJOR_VERSION}" -ne "${MAJOR_VERSION}" ]; then
+if [ "${EXPECTED_MAJOR_VERSION}" != "${MAJOR_VERSION}" ]; then
     echo "[FAIL] Expected major version ${EXPECTED_MAJOR_VERSION} to be installed, but found ${MAJOR_VERSION}"
     RESULT=1
 else
@@ -42,7 +42,7 @@ else
 fi
 
 if [ -n "${EXPECTED_MINOR_VERSION}" ]; then
-    if [ "${EXPECTED_MINOR_VERSION}" -ne "${MINOR_VERSION}" ]; then
+    if [ "${EXPECTED_MINOR_VERSION}" != "${MINOR_VERSION}" ]; then
         echo "[FAIL] Expected minor version ${EXPECTED_MINOR_VERSION} to be installed, but found ${MINOR_VERSION}"
         RESULT=1
     else


### PR DESCRIPTION
## Changes : 
  - Ubuntu 14 tests didn't trigger an error when ``EXPECTED_MINOR_VERSION != MINOR_VERSION``. Previously we used ``-ne`` in the condition. But in the case where ``MINOR_VERSION`` is empty, ``test $VERSION -ne $EMPTY_VERSION`` would result in an error returning false. Meaning that it wouldn't enter the if that was supposed to handle error and be considered as valid when it wasn't. That's why ``-ne`` has been replaced with ``!=`` that handle the comparaison as string so even empty string would trigger the error.
  - ``MINOR_VERSION`` is empty because ubuntu 14's dpkg-query version is 1.17.x which is inferior of 1.18.16 needed to use the format ``Upstream-Version``. Instead we manually parse the version manually with ``sed``