### PR TITLE
Install injection libraries with agent install script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,6 +83,20 @@ test:
     - ./test/dockertest.sh --image "registry.ddbuild.io/${IMAGE}" --script install_script_agent6.sh --minor-version "${MINOR_VERSION}" --expected-minor-version "${EXPECTED_MINOR_VERSION}" --flavor "${FLAVOR}"
     - ./test/dockertest.sh --image "registry.ddbuild.io/${IMAGE}" --script install_script_agent7.sh --minor-version "${MINOR_VERSION}" --expected-minor-version "${EXPECTED_MINOR_VERSION}" --flavor "${FLAVOR}"
 
+test-apm-injection:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:docker"]
+  stage: test
+  dependencies: ["generate-scripts"]
+  parallel:
+    matrix:
+      - IMAGE: images/mirror/ubuntu:14.04
+      - IMAGE: images/mirror/ubuntu:22.04
+      - IMAGE: images/mirror/centos:centos7
+
+  script:
+    - ./test/dockertest.sh --image "registry.ddbuild.io/${IMAGE}" --script install_script_agent7.sh --host-injection true
+
 .deploy:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,13 +89,19 @@ test-apm-injection:
   stage: test
   dependencies: ["generate-scripts"]
   parallel:
+    # Docker testing is not possible because of docker-in-docker
+    # Host injection requires the agent to be present
+    # NO_AGENT only makes sense with docker, or specifically installing apm libraries
+    # The matrix below tests the possible combinations with a subset of OSes
     matrix:
-      - IMAGE: images/mirror/ubuntu:14.04
-      - IMAGE: images/mirror/ubuntu:22.04
-      - IMAGE: images/mirror/centos:centos7
+      - IMAGE: ["images/mirror/ubuntu:14.04", "images/mirror/ubuntu:22.04", "images/mirror/centos:centos7" ]
+        HOST_INJECTION: "true"
+      - IMAGE: ["images/mirror/ubuntu:14.04", "images/mirror/ubuntu:22.04", "images/mirror/centos:centos7" ]
+        NO_AGENT: "true"
+        APM_LIBRARIES: "all"
 
   script:
-    - ./test/dockertest.sh --image "registry.ddbuild.io/${IMAGE}" --script install_script_agent7.sh --host-injection true
+    - ./test/dockertest.sh --image "registry.ddbuild.io/${IMAGE}" --script install_script_agent7.sh --host-injection "$HOST_INJECTION" --no-agent "$NO_AGENT" --apm-libraries "$APM_LIBRARIES"
 
 .deploy:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -324,6 +324,54 @@ if [ -n "$DD_FIPS_MODE" ]; then
   fips_mode=$DD_FIPS_MODE
 fi
 
+declare -a apm_libraries
+
+host_injection_enabled=
+if [ -n "$DD_APM_HOST_INJECTION_ENABLED" ]; then
+  host_injection_enabled=$DD_APM_HOST_INJECTION_ENABLED
+  apm_libraries=("datadog-apm-inject")
+fi
+
+docker_injection_enabled=
+if [ -n "$DD_APM_DOCKER_INJECTION_ENABLED" ]; then
+  docker_injection_enabled=$DD_APM_DOCKER_INJECTION_ENABLED
+  apm_libraries=("datadog-apm-inject")
+fi
+
+if [ -n "$DD_APM_LIBRARIES" ]; then
+  lib_array=($DD_APM_LIBRARIES)
+  for lib in "${lib_array[@]}"
+  do
+    case $lib in
+      all)
+        apm_libraries+=("datadog-apm-library-all")
+        ;;
+      java)
+        apm_libraries+=("datadog-apm-library-java")
+        ;;
+      js)
+        apm_libraries+=("datadog-apm-library-js")
+        ;;
+      python)
+        apm_libraries+=("datadog-apm-library-python")
+        ;;
+      dotnet)
+        apm_libraries+=("datadog-apm-library-dotnet")
+        ;;
+      *)
+        ERROR_MESSAGE="Unknown apm library: $lib. Must be one of: all, java, js, python, dotnet"
+        ERROR_CODE=$INVALID_PARAMETERS_CODE
+        echo "$ERROR_MESSAGE"
+        report_telemetry
+        exit 1;
+        ;;
+    esac
+  done
+elif [ -n "$host_injection_enabled" ] || [ -n "$docker_injection_enabled" ]; then
+  # Default to all libraries if injection is enabled
+  apm_libraries+=("datadog-apm-library-all")
+fi
+
 system_probe_ensure_config=
 if [ -n "$DD_SYSTEM_PROBE_ENSURE_CONFIG" ]; then
   system_probe_ensure_config=$DD_SYSTEM_PROBE_ENSURE_CONFIG
@@ -601,6 +649,10 @@ if [ "$OS" = "RedHat" ]; then
       packages+=("datadog-fips-proxy")
     fi
 
+    if [ -n "$apm_libraries" ]; then
+      packages+=(${apm_libraries[@]})
+    fi
+
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
     $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}"
@@ -689,6 +741,10 @@ If the cause is unclear, please contact Datadog support.
     packages=("$agent_flavor" "datadog-signing-keys")
     if [ -n "$fips_mode" ]; then
      packages+=("datadog-fips-proxy")
+    fi
+
+    if [ -n "$apm_libraries" ]; then
+      packages+=(${apm_libraries[@]})
     fi
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
@@ -826,6 +882,13 @@ elif [ "$OS" = "SUSE" ]; then
     packages+=("datadog-fips-proxy")
   fi
 
+  if [ -n "$apm_libraries" ]; then
+    ERROR_MESSAGE="APM injection is not supported on SUSE"
+    ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
+    echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
+    report_telemetry
+    exit 1;
+  fi
 
   echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
@@ -959,6 +1022,17 @@ if [ -n "$system_probe_ensure_config" ]; then
   fi
 fi
 
+# run apm injection scripts
+if [ -n "$host_injection_enabled" ]; then
+  echo "in host install"
+  $sudo_cmd dd-host-install --no-agent-restart
+  echo "finished host install"
+fi
+
+if [ -n "$docker_injection_enabled" ]; then
+  $sudo_cmd dd-container-install --no-agent-restart
+fi
+
 # Creating or overriding the install information
 install_info_content="---
 install_method:
@@ -967,7 +1041,6 @@ install_method:
   installer_version: install_script-$install_script_version
 "
 $sudo_cmd sh -c "echo '$install_info_content' > $etcdir/install_info"
-
 if [ -n "$fips_mode" ]; then
   # Creating or overriding the install information
   $sudo_cmd sh -c "echo '$install_info_content' > $etcdirfips/install_info"
@@ -988,7 +1061,6 @@ monitoring_services=( "datadog-agent" )
 if [ $no_start ]; then
   printf "\033[34m\n  * DD_INSTALL_ONLY environment variable set.\033[0m\n"
 fi
-
 for current_service in "${services[@]}"; do
   nice_current_flavor=${flavor_to_readable[$current_service]}
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -333,13 +333,13 @@ declare -a apm_libraries
 
 host_injection_enabled=
 if [[ "$DD_APM_HOST_INJECTION_ENABLED" == "true" || ( -z "$DD_APM_HOST_INJECTION_ENABLED" && "$DD_APM_INSTRUMENTATION_ENABLED" == "true") ]] ; then
-  host_injection_enabled=$DD_APM_HOST_INJECTION_ENABLED
+  host_injection_enabled="true"
   apm_libraries=("datadog-apm-inject")
 fi
 
 docker_injection_enabled=
 if [[ "$DD_APM_DOCKER_INJECTION_ENABLED" == "true" || ( -z "$DD_APM_DOCKER_INJECTION_ENABLED" && "$DD_APM_INSTRUMENTATION_ENABLED" == "true") ]] ; then
-  docker_injection_enabled=$DD_APM_DOCKER_INJECTION_ENABLED
+  docker_injection_enabled="true"
   apm_libraries=("datadog-apm-inject")
 fi
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -333,6 +333,14 @@ declare -a apm_libraries
 
 host_injection_enabled=
 if [[ "$DD_APM_HOST_INJECTION_ENABLED" == "true" || ( -z "$DD_APM_HOST_INJECTION_ENABLED" && "$DD_APM_INSTRUMENTATION_ENABLED" == "true") ]] ; then
+  if [ "$no_agent" ]; then
+      ERROR_MESSAGE="Host injection is not supported with the DD_NO_AGENT_INSTALL flag. Disable host injection with DD_APM_HOST_INJECTION_ENABLED=false or unset DD_NO_AGENT_INSTALL"
+      ERROR_CODE=$INVALID_PARAMETERS_CODE
+      echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
+      report_telemetry
+      exit 1;
+  fi
+
   host_injection_enabled="true"
   apm_libraries=("datadog-apm-inject")
 fi
@@ -519,6 +527,14 @@ if [[ `uname -m` == "armv7l" ]] && [[ $agent_flavor == "datadog-agent" ]] && [ !
     printf "\033[31m$ERROR_MESSAGE\033[0m\n"
     report_telemetry
     exit 1;
+fi
+
+if [ ${#apm_libraries[@]} -gt 0 ] && [ $agent_major_version = "6" ] ; then
+  ERROR_MESSAGE="APM library injection is not supported with Agent version 6"
+  ERROR_CODE=$INVALID_PARAMETERS_CODE
+  echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
+  report_telemetry
+  exit 1;
 fi
 
 # OS/Distro Detection

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1062,7 +1062,10 @@ install_method:
   tool_version: install_scriptINSTALL_INFO_VERSION_PLACEHOLDER
   installer_version: install_script-$install_script_version
 "
-$sudo_cmd sh -c "echo '$install_info_content' > $etcdir/install_info"
+
+if [ ! "$no_agent" ]; then
+  $sudo_cmd sh -c "echo '$install_info_content' > $etcdir/install_info"
+fi
 
 if [ -n "$fips_mode" ]; then
   # Creating or overriding the install information

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1062,8 +1062,8 @@ install_method:
   tool_version: install_scriptINSTALL_INFO_VERSION_PLACEHOLDER
   installer_version: install_script-$install_script_version
 "
-
 $sudo_cmd sh -c "echo '$install_info_content' > $etcdir/install_info"
+
 if [ -n "$fips_mode" ]; then
   # Creating or overriding the install information
   $sudo_cmd sh -c "echo '$install_info_content' > $etcdirfips/install_info"
@@ -1084,6 +1084,7 @@ monitoring_services=( "datadog-agent" )
 if [ $no_start ]; then
   printf "\033[34m\n  * DD_INSTALL_ONLY environment variable set.\033[0m\n"
 fi
+
 for current_service in "${services[@]}"; do
   nice_current_flavor=${flavor_to_readable[$current_service]}
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -344,7 +344,7 @@ if [ -n "$DD_APM_DOCKER_INJECTION_ENABLED" ]; then
 fi
 
 if [ -n "$DD_APM_LIBRARIES" ]; then
-  lib_array=($DD_APM_LIBRARIES)
+  read -r -a lib_array <<< "$DD_APM_LIBRARIES"
   for lib in "${lib_array[@]}"
   do
     case $lib in
@@ -417,7 +417,7 @@ declare -a services
 if [ "$no_agent" ]; then
   services=()
 else
-  services=($system_service)
+  services=("$system_service")
 fi
 
 if [ -n "$fips_mode" ]; then
@@ -664,8 +664,8 @@ if [ "$OS" = "RedHat" ]; then
       packages+=("datadog-fips-proxy")
     fi
 
-    if [ -n "$apm_libraries" ]; then
-      packages+=(${apm_libraries[@]})
+    if [ ${#apm_libraries[@]} -gt 0 ]; then
+      packages+=("${apm_libraries[@]}")
     fi
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
@@ -762,8 +762,8 @@ If the cause is unclear, please contact Datadog support.
      packages+=("datadog-fips-proxy")
     fi
 
-    if [ -n "$apm_libraries" ]; then
-      packages+=(${apm_libraries[@]})
+    if [ ${#apm_libraries[@]} -gt 0 ]; then
+      packages+=("${apm_libraries[@]}")
     fi
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
@@ -904,7 +904,7 @@ elif [ "$OS" = "SUSE" ]; then
     packages+=("datadog-fips-proxy")
   fi
 
-  if [ -n "$apm_libraries" ]; then
+  if [ ${#apm_libraries[@]} -gt 0 ]; then
     ERROR_MESSAGE="APM injection is not supported on SUSE"
     ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
     echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -254,6 +254,11 @@ if [ -n "$DD_INSTALL_ONLY" ]; then
     no_start=true
 fi
 
+no_agent=
+if [ -n "$DD_NO_AGENT_INSTALL" ]; then
+    no_agent=true
+fi
+
 host_tags=
 # comma-separated list of tags
 if [ -n "$DD_HOST_TAGS" ]; then
@@ -408,7 +413,13 @@ flavor_to_system_service=(
 system_service=${flavor_to_system_service[$agent_flavor]:-datadog-agent}
 
 declare -a services
-services=("$system_service")
+
+if [ "$no_agent" ]; then
+  services=()
+else
+  services=($system_service)
+fi
+
 if [ -n "$fips_mode" ]; then
   services+=("datadog-fips-proxy")
 fi
@@ -496,13 +507,13 @@ fi
 
 if [ ! "$apikey" ]; then
   # if it's an upgrade, then we will use the transition script
-  if [ ! "$upgrade" ] && [ ! -e "$config_file" ]; then
+  if [ ! "$upgrade" ] && [ ! -e "$config_file" ] && [ ! "$no_agent" ]; then
     printf "\033[31mAPI key not available in DD_API_KEY environment variable.\033[0m\n"
     exit 1;
   fi
 fi
 
-if [[ `uname -m` == "armv7l" ]] && [[ $agent_flavor == "datadog-agent" ]]; then
+if [[ `uname -m` == "armv7l" ]] && [[ $agent_flavor == "datadog-agent" ]] && [ ! "$no_agent" ]; then
     ERROR_MESSAGE="The full $nice_flavor isn't available for your architecture (armv7l).\nInstall the ${flavor_to_readable[datadog-iot-agent]} by setting DD_AGENT_FLAVOR='datadog-iot-agent'."
     ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
     printf "\033[31m$ERROR_MESSAGE\033[0m\n"
@@ -644,7 +655,12 @@ if [ "$OS" = "RedHat" ]; then
     fi
 
     declare -a packages
-    packages=("$agent_flavor")
+    if [ "$no_agent" ]; then
+      packages=()
+    else
+      packages=("$agent_flavor")
+    fi
+
     if [ -n "$fips_mode" ]; then
       packages+=("datadog-fips-proxy")
     fi
@@ -738,7 +754,12 @@ If the cause is unclear, please contact Datadog support.
     fi
 
     declare -a packages
-    packages=("$agent_flavor" "datadog-signing-keys")
+    if [ "$no_agent" ]; then
+      packages=("datadog-signing-keys")
+    else
+      packages=("$agent_flavor" "datadog-signing-keys")
+    fi
+
     if [ -n "$fips_mode" ]; then
      packages+=("datadog-fips-proxy")
     fi
@@ -877,7 +898,12 @@ elif [ "$OS" = "SUSE" ]; then
   fi
 
   declare -a packages
-  packages=("$agent_flavor")
+  if [ "$no_agent" ]; then
+    packages=()
+  else
+    packages=("$agent_flavor")
+  fi
+
   if [ -n "$fips_mode" ]; then
     packages+=("datadog-fips-proxy")
   fi
@@ -1024,9 +1050,7 @@ fi
 
 # run apm injection scripts
 if [ -n "$host_injection_enabled" ]; then
-  echo "in host install"
   $sudo_cmd dd-host-install --no-agent-restart
-  echo "finished host install"
 fi
 
 if [ -n "$docker_injection_enabled" ]; then
@@ -1040,6 +1064,7 @@ install_method:
   tool_version: install_scriptINSTALL_INFO_VERSION_PLACEHOLDER
   installer_version: install_script-$install_script_version
 "
+
 $sudo_cmd sh -c "echo '$install_info_content' > $etcdir/install_info"
 if [ -n "$fips_mode" ]; then
   # Creating or overriding the install information

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -636,7 +636,6 @@ if [ "$OS" = "RedHat" ]; then
 
     $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://${yum_url}/${yum_version_path}/${ARCHI}/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=${rpm_repo_gpgcheck}\npriority=1\ngpgkey=${gpgkeys}' > /etc/yum.repos.d/datadog.repo"
 
-    printf "\033[34m* Installing the $nice_flavor package\n\033[0m\n"
     $sudo_cmd yum -y clean metadata
 
     dnf_flag=""
@@ -729,7 +728,6 @@ elif [ "$OS" = "Debian" ]; then
       fi
     fi
 
-    printf "\033[34m\n* Installing the $nice_flavor package\n\033[0m\n"
     ERROR_MESSAGE="ERROR
 Failed to update the sources after adding the Datadog repository.
 This may be due to any of the configured APT sources failing -
@@ -851,8 +849,6 @@ elif [ "$OS" = "SUSE" ]; then
   echo -e "\033[34m\n* Refreshing repositories\n\033[0m"
   $sudo_cmd zypper --non-interactive --no-gpg-checks refresh datadog
 
-  echo -e "\033[34m\n* Installing the $nice_flavor package\n\033[0m"
-
   # ".32" is the latest version supported for OpenSUSE < 15 and SLES < 12
   # we explicitly test for SUSE11 = "yes", as some SUSE11 don't have /etc/os-release, thus SUSE_VER is empty
   if [ "$DISTRIBUTION" == "openSUSE" ] && { [ "$SUSE11" == "yes" ] || [ "$SUSE_VER" -lt 15 ]; }; then
@@ -965,7 +961,7 @@ fi
 # Set the configuration
 if [ -e "$config_file" ] && [ -z "$upgrade" ]; then
   printf "\033[34m\n* Keeping old $config_file configuration file\n\033[0m\n"
-else
+elif [ ! "$no_agent" ]; then
   if [ ! -e "$config_file" ]; then
     $sudo_cmd cp "$config_file.example" "$config_file"
   fi
@@ -1014,8 +1010,10 @@ EOF
   fi
 fi
 
-$sudo_cmd chown dd-agent:dd-agent "$config_file"
-$sudo_cmd chmod 640 "$config_file"
+if [ ! "$no_agent" ]; then
+  $sudo_cmd chown dd-agent:dd-agent "$config_file"
+  $sudo_cmd chmod 640 "$config_file"
+fi
 
 # set the FIPS configuration
 if [ -n "$fips_mode" ]; then

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -332,13 +332,13 @@ fi
 declare -a apm_libraries
 
 host_injection_enabled=
-if [ -n "$DD_APM_HOST_INJECTION_ENABLED" ]; then
+if [[ "$DD_APM_HOST_INJECTION_ENABLED" == "true" || ( -z "$DD_APM_HOST_INJECTION_ENABLED" && "$DD_APM_INSTRUMENTATION_ENABLED" == "true") ]] ; then
   host_injection_enabled=$DD_APM_HOST_INJECTION_ENABLED
   apm_libraries=("datadog-apm-inject")
 fi
 
 docker_injection_enabled=
-if [ -n "$DD_APM_DOCKER_INJECTION_ENABLED" ]; then
+if [[ "$DD_APM_DOCKER_INJECTION_ENABLED" == "true" || ( -z "$DD_APM_DOCKER_INJECTION_ENABLED" && "$DD_APM_INSTRUMENTATION_ENABLED" == "true") ]] ; then
   docker_injection_enabled=$DD_APM_DOCKER_INJECTION_ENABLED
   apm_libraries=("datadog-apm-inject")
 fi

--- a/test/dockertest.sh
+++ b/test/dockertest.sh
@@ -22,6 +22,9 @@ while [[ $# -gt 0 ]]; do
     -p|--platform)
       PLATFORM="$2"
       ;;
+    --host-injection)
+      DD_APM_HOST_INJECTION_ENABLED="$2"
+      ;;
     -*|--*)
       echo "Unknown option $1"
       exit 1
@@ -33,4 +36,4 @@ done
 [ -z "$SCRIPT" ] && echo "Please provide script file to test via -s/--script" && exit 1;
 [ -z "$IMAGE" ] && echo "Please provide image to test via -i/--image" && exit 1;
 
-docker run --rm --platform $PLATFORM -v $(pwd):/tmp/vol -e DD_SYSTEM_PROBE_ENSURE_CONFIG="${DD_SYSTEM_PROBE_ENSURE_CONFIG}" -e DD_INSTALL_ONLY=true -e DD_AGENT_MINOR_VERSION="${MINOR_VERSION}" -e DD_AGENT_FLAVOR="${FLAVOR}" -e EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION}" -e DD_API_KEY=123 -e SCRIPT="/tmp/vol/$SCRIPT" --entrypoint /tmp/vol/test/localtest.sh "$IMAGE"
+docker run --rm --platform $PLATFORM -v $(pwd):/tmp/vol -e DD_SYSTEM_PROBE_ENSURE_CONFIG="${DD_SYSTEM_PROBE_ENSURE_CONFIG}" -e DD_INSTALL_ONLY=true -e DD_AGENT_MINOR_VERSION="${MINOR_VERSION}" -e DD_AGENT_FLAVOR="${FLAVOR}" -e EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION}" -e DD_API_KEY=123 -e SCRIPT="/tmp/vol/$SCRIPT" -e DD_APM_HOST_INJECTION_ENABLED="${DD_APM_HOST_INJECTION_ENABLED}" --entrypoint /tmp/vol/test/localtest.sh "$IMAGE"

--- a/test/dockertest.sh
+++ b/test/dockertest.sh
@@ -25,6 +25,12 @@ while [[ $# -gt 0 ]]; do
     --host-injection)
       DD_APM_HOST_INJECTION_ENABLED="$2"
       ;;
+    --apm-libraries)
+      DD_APM_LIBRARIES="$2"
+      ;;
+    --no-agent)
+      DD_NO_AGENT_INSTALL="$2"
+      ;;
     -*|--*)
       echo "Unknown option $1"
       exit 1
@@ -36,4 +42,13 @@ done
 [ -z "$SCRIPT" ] && echo "Please provide script file to test via -s/--script" && exit 1;
 [ -z "$IMAGE" ] && echo "Please provide image to test via -i/--image" && exit 1;
 
-docker run --rm --platform $PLATFORM -v $(pwd):/tmp/vol -e DD_SYSTEM_PROBE_ENSURE_CONFIG="${DD_SYSTEM_PROBE_ENSURE_CONFIG}" -e DD_INSTALL_ONLY=true -e DD_AGENT_MINOR_VERSION="${MINOR_VERSION}" -e DD_AGENT_FLAVOR="${FLAVOR}" -e EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION}" -e DD_API_KEY=123 -e SCRIPT="/tmp/vol/$SCRIPT" -e DD_APM_HOST_INJECTION_ENABLED="${DD_APM_HOST_INJECTION_ENABLED}" --entrypoint /tmp/vol/test/localtest.sh "$IMAGE"
+docker run --rm --platform $PLATFORM -v $(pwd):/tmp/vol \
+  -e DD_SYSTEM_PROBE_ENSURE_CONFIG="${DD_SYSTEM_PROBE_ENSURE_CONFIG}" \
+  -e DD_INSTALL_ONLY=true -e DD_AGENT_MINOR_VERSION="${MINOR_VERSION}" \
+  -e DD_AGENT_FLAVOR="${FLAVOR}" \
+  -e EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION}" \
+  -e DD_API_KEY=123 -e SCRIPT="/tmp/vol/$SCRIPT" \
+  -e DD_APM_HOST_INJECTION_ENABLED="${DD_APM_HOST_INJECTION_ENABLED}" \
+  -e DD_NO_AGENT_INSTALL="$DD_NO_AGENT_INSTALL" \
+  -e DD_APM_LIBRARIES="$DD_APM_LIBRARIES" \
+  --entrypoint /tmp/vol/test/localtest.sh "$IMAGE"

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -103,4 +103,31 @@ if [ -n "${DD_SYSTEM_PROBE_ENSURE_CONFIG}" ]; then
     fi
 fi
 
+if [ "$DD_APM_HOST_INJECTION_ENABLED" = "true" ]; then
+  if command -v dpkg > /dev/null; then
+      debsums -c datadog-apm-inject
+      debsums -c datadog-apm-library-all
+  else
+      rpm --verify --nomode --nouser --nogroup datadog-apm-inject
+      rpm --verify --nomode --nouser --nogroup datadog-apm-library-all
+  fi
+
+  if [ -f "/etc/ld.so.preload" ]; then
+    echo "[OK] /etc/ld.so.preload exists"
+  else
+    echo "[FAIL] Expected to find /etc/ld.so.preload"
+    RESULT=1
+  fi
+else
+  if command -v dpkg > /dev/null && debsums -c datadog-apm-inject ; then
+    echo "[FAIL] datadog-apm-inject should not be installed"
+    RESULT=1
+  elif rpm --verify --nomode --nouser --nogroup datadog-apm-inject ; then
+    echo "[FAIL] datadog-apm-inject should not be installed"
+    RESULT=1
+  else
+    echo "[OK] datadog-apm-inject is not installed"
+  fi
+fi
+
 exit ${RESULT}

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -19,13 +19,24 @@ EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION:-${DD_AGENT_MINOR_VERSION}}"
 # basic checks to ensure that the correct flavor was installed
 if command -v dpkg > /dev/null; then
     apt-get install -y debsums
-    debsums -c ${EXPECTED_FLAVOR}
-    INSTALLED_VERSION=$(dpkg-query -W ${EXPECTED_FLAVOR} | cut -f2 | cut -d: -f2)
+
+    if [ -z "$DD_NO_AGENT_INSTALL" ]; then
+      debsums -c ${EXPECTED_FLAVOR}
+      INSTALLED_VERSION=$(dpkg-query -W ${EXPECTED_FLAVOR} | cut -f2 | cut -d: -f2)
+    elif debsums -c datadog-agent ; then
+      echo "[FAIL] datadog-agent should not be installed"
+      RESULT=1
+    fi
 else
-    # skip verification of mode/user/group, because these are
-    # changed by the postinstall scriptlet
-    rpm --verify --nomode --nouser --nogroup "${EXPECTED_FLAVOR}"
-    INSTALLED_VERSION=$(rpm -q --qf "%{version}" "${EXPECTED_FLAVOR}")
+    if [ -z "$DD_NO_AGENT_INSTALL" ]; then
+      # skip verification of mode/user/group, because these are
+      # changed by the postinstall scriptlet
+      rpm --verify --nomode --nouser --nogroup "${EXPECTED_FLAVOR}"
+      INSTALLED_VERSION=$(rpm -q --qf "%{version}" "${EXPECTED_FLAVOR}")
+    elif rpm --verify --nomode --nouser --nogroup datadog-agent ; then
+      echo "[FAIL] datadog-agent should not be installed"
+      RESULT=1
+    fi
 fi
 
 echo -e "\n"
@@ -33,12 +44,13 @@ echo -e "\n"
 MAJOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 1)
 MINOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d "." -f 2)
 
-
-if [ "${EXPECTED_MAJOR_VERSION}" != "${MAJOR_VERSION}" ]; then
-    echo "[FAIL] Expected major version ${EXPECTED_MAJOR_VERSION} to be installed, but found ${MAJOR_VERSION}"
-    RESULT=1
-else
-    echo "[OK] Correct major version installed"
+if [ -z "$DD_NO_AGENT_INSTALL" ]; then
+  if [ "${EXPECTED_MAJOR_VERSION}" != "${MAJOR_VERSION}" ]; then
+      echo "[FAIL] Expected major version ${EXPECTED_MAJOR_VERSION} to be installed, but found ${MAJOR_VERSION}"
+      RESULT=1
+  else
+      echo "[OK] Correct major version installed"
+  fi
 fi
 
 if [ -n "${EXPECTED_MINOR_VERSION}" ]; then
@@ -64,7 +76,7 @@ else
     RESULT=1
 fi
 
-if [ -n "${EXPECTED_TOOL_VERSION}" ]; then
+if [ -n "${EXPECTED_TOOL_VERSION}" ] && [ -z "$DD_NO_AGENT_INSTALL" ]; then
     INSTALL_INFO_FILE=/etc/datadog-agent/install_info
     if [ "${EXPECTED_FLAVOR}" = "datadog-dogstatsd" ]; then
         INSTALL_INFO_FILE=/etc/datadog-dogstatsd/install_info
@@ -107,9 +119,11 @@ if [ "$DD_APM_HOST_INJECTION_ENABLED" = "true" ]; then
   if command -v dpkg > /dev/null; then
       debsums -c datadog-apm-inject
       debsums -c datadog-apm-library-all
+      echo "[OK] Inject libraries installed"
   else
       rpm --verify --nomode --nouser --nogroup datadog-apm-inject
       rpm --verify --nomode --nouser --nogroup datadog-apm-library-all
+      echo "[OK] Inject libraries installed"
   fi
 
   if [ -f "/etc/ld.so.preload" ]; then
@@ -127,6 +141,16 @@ else
     RESULT=1
   else
     echo "[OK] datadog-apm-inject is not installed"
+  fi
+fi
+
+if [ -n "$DD_APM_LIBRARIES" ]; then
+  if command -v dpkg > /dev/null; then
+    debsums -c datadog-apm-library-all
+    echo "[OK] Inject libraries installed"
+  else
+    rpm --verify --nomode --nouser --nogroup datadog-apm-library-all
+    echo "[OK] Inject libraries installed"
   fi
 fi
 


### PR DESCRIPTION
This PR adds the ability to install autoinstrumentation libraries after setting environment variables.

| Variable name | Description |
| ---------------|------------|
| DD_APM_INSTRUMENTATION_ENABLED | Install host and docker injection unless overridden with a more specific env variable |
| DD_APM_HOST_INJECTION_ENABLED |  Installs or prevents installation of host injection (via `LD_PRELOAD`) |
| DD_APM_DOCKER_INJECTION_ENABLED | Installs or prevents installation of docker injection ( via `daemon.json` ) |
| DD_APM_LIBRARIES | Space separated list of which languages to install support for. Valid values are `js`, `java`, `python`, `dotnet`, `all`.  Defaults to `all` if host or docker injection is enabled | 
| DD_NO_AGENT_INSTALL | If set, don't install the datadog agent. This is useful for the container injection only case. The check is for the existence of the variable, not any particular value. This mirrors DD_INSTALL_ONLY |

* The script does not verify that all combinations of new and existing variables make sense together (for instance `DD_NO_AGENT_INSTALL` and `DD_AGENT_MINOR_VERSION`)
* I removed the `Installing the $nice_flavor package` log statement because it is redundant with `Installing package(s) ...` line that follows and is misleading in some cases.

### Testing
I added few basic checks to the test suite. Only host injection could be tested because of the docker-in-docker issue.

### Additional Info:
* this PR depends on some fixes to the auto inject packages (https://github.com/DataDog/auto_inject/pull/57, https://github.com/DataDog/auto_inject/pull/55, https://github.com/DataDog/auto_inject/pull/54) being released
