### PR TITLE
Only replace top-level tags entry in config

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1036,7 +1036,7 @@ EOF
   if [ "$host_tags" ]; then
       printf "\033[34m\n* Adding your HOST TAGS to the $nice_flavor configuration: $config_file\n\033[0m\n"
       formatted_host_tags="['""$( echo "$host_tags" | sed "s/,/','/g" )""']"  # format `env:prod,foo:bar` to yaml-compliant `['env:prod','foo:bar']`
-      $sudo_cmd sh -c "sed -i \"s/# tags:.*/tags: ""$formatted_host_tags""/\" $config_file"
+      $sudo_cmd sh -c "sed -i \"s/^# tags:.*/tags: ""$formatted_host_tags""/\" $config_file"
   fi
 fi
 


### PR DESCRIPTION
As of 7.45.0, there's an additional `# tags:` entry in the Agent config file, but that doesn't start at the beginning of the line. This PR ensures we don't accidentally replace that as well.