### PR TITLE
Fix APM variable names and behavior

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,13 +95,13 @@ test-apm-injection:
     # The matrix below tests the possible combinations with a subset of OSes
     matrix:
       - IMAGE: ["images/mirror/ubuntu:14.04", "images/mirror/ubuntu:22.04", "images/mirror/centos:centos7" ]
-        HOST_INJECTION: "true"
+        INJECTION: "host"
       - IMAGE: ["images/mirror/ubuntu:14.04", "images/mirror/ubuntu:22.04", "images/mirror/centos:centos7" ]
         NO_AGENT: "true"
         APM_LIBRARIES: "all"
 
   script:
-    - ./test/dockertest.sh --image "registry.ddbuild.io/${IMAGE}" --script install_script_agent7.sh --host-injection "$HOST_INJECTION" --no-agent "$NO_AGENT" --apm-libraries "$APM_LIBRARIES"
+    - ./test/dockertest.sh --image "registry.ddbuild.io/${IMAGE}" --script install_script_agent7.sh --injection "$INJECTION" --no-agent "$NO_AGENT" --apm-libraries "$APM_LIBRARIES"
 
 .deploy:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -330,25 +330,45 @@ if [ -n "$DD_FIPS_MODE" ]; then
 fi
 
 declare -a apm_libraries
+declare host_injection_enabled
+declare docker_injection_enabled
 
-host_injection_enabled=
-if [[ "$DD_APM_HOST_INJECTION_ENABLED" == "true" || ( -z "$DD_APM_HOST_INJECTION_ENABLED" && "$DD_APM_INSTRUMENTATION_ENABLED" == "true") ]] ; then
-  if [ "$no_agent" ]; then
-      ERROR_MESSAGE="Host injection is not supported with the DD_NO_AGENT_INSTALL flag. Disable host injection with DD_APM_HOST_INJECTION_ENABLED=false or unset DD_NO_AGENT_INSTALL"
-      ERROR_CODE=$INVALID_PARAMETERS_CODE
-      echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
-      report_telemetry
-      exit 1;
-  fi
-
-  host_injection_enabled="true"
-  apm_libraries=("datadog-apm-inject")
+if [ -n "$DD_APM_INSTRUMENTATION_ENABLED" ]; then
+  read -r -a target_array <<< "$DD_APM_INSTRUMENTATION_ENABLED"
+  for target in "${target_array[@]}"
+  do
+    case $target in
+      all)
+        host_injection_enabled="true"
+        docker_injection_enabled="true"
+        ;;
+      docker)
+        docker_injection_enabled="true"
+        ;;
+      host)
+        host_injection_enabled="true"
+        ;;
+      *)
+        ERROR_MESSAGE="Unknown instrumentation target: $target. Must be one of: all, docker, host"
+        ERROR_CODE=$INVALID_PARAMETERS_CODE
+        echo "$ERROR_MESSAGE"
+        report_telemetry
+        exit 1;
+        ;;
+    esac
+  done
 fi
 
-docker_injection_enabled=
-if [[ "$DD_APM_DOCKER_INJECTION_ENABLED" == "true" || ( -z "$DD_APM_DOCKER_INJECTION_ENABLED" && "$DD_APM_INSTRUMENTATION_ENABLED" == "true") ]] ; then
-  docker_injection_enabled="true"
-  apm_libraries=("datadog-apm-inject")
+if [ -n "${host_injection_enabled}${docker_injection_enabled}" ] ; then
+    apm_libraries=("datadog-apm-inject")
+fi
+
+if [ -n "${host_injection_enabled}" ] && [ -n "${no_agent}" ] ; then
+    ERROR_MESSAGE="Host injection is not supported with the DD_NO_AGENT_INSTALL flag. Disable host injection with DD_APM_HOST_INJECTION_ENABLED=false or unset DD_NO_AGENT_INSTALL"
+    ERROR_CODE=$INVALID_PARAMETERS_CODE
+    echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
+    report_telemetry
+    exit 1;
 fi
 
 daemon_config_dir="/etc/docker"
@@ -363,8 +383,8 @@ if [ -n "$docker_injection_enabled" ]; then
     fi
 fi
 
-if [ -n "$DD_APM_LIBRARIES" ]; then
-  read -r -a lib_array <<< "$DD_APM_LIBRARIES"
+if [ -n "$DD_APM_INSTRUMENTATION_LANGUAGES" ]; then
+  read -r -a lib_array <<< "$DD_APM_INSTRUMENTATION_LANGUAGES"
   for lib in "${lib_array[@]}"
   do
     case $lib in

--- a/test/dockertest.sh
+++ b/test/dockertest.sh
@@ -22,11 +22,11 @@ while [[ $# -gt 0 ]]; do
     -p|--platform)
       PLATFORM="$2"
       ;;
-    --host-injection)
-      DD_APM_HOST_INJECTION_ENABLED="$2"
+    --injection)
+      DD_APM_INSTRUMENTATION_ENABLED="$2"
       ;;
     --apm-libraries)
-      DD_APM_LIBRARIES="$2"
+      DD_APM_INSTRUMENTATION_LANGUAGES="$2"
       ;;
     --no-agent)
       DD_NO_AGENT_INSTALL="$2"
@@ -48,7 +48,7 @@ docker run --rm --platform $PLATFORM -v $(pwd):/tmp/vol \
   -e DD_AGENT_FLAVOR="${FLAVOR}" \
   -e EXPECTED_MINOR_VERSION="${EXPECTED_MINOR_VERSION}" \
   -e DD_API_KEY=123 -e SCRIPT="/tmp/vol/$SCRIPT" \
-  -e DD_APM_HOST_INJECTION_ENABLED="${DD_APM_HOST_INJECTION_ENABLED}" \
+  -e DD_APM_INSTRUMENTATION_ENABLED="${DD_APM_INSTRUMENTATION_ENABLED}" \
   -e DD_NO_AGENT_INSTALL="$DD_NO_AGENT_INSTALL" \
-  -e DD_APM_LIBRARIES="$DD_APM_LIBRARIES" \
+  -e DD_APM_INSTRUMENTATION_LANGUAGES="${DD_APM_INSTRUMENTATION_LANGUAGES}" \
   --entrypoint /tmp/vol/test/localtest.sh "$IMAGE"

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -115,7 +115,7 @@ if [ -n "${DD_SYSTEM_PROBE_ENSURE_CONFIG}" ]; then
     fi
 fi
 
-if [ "$DD_APM_HOST_INJECTION_ENABLED" = "true" ]; then
+if [ "$DD_APM_INSTRUMENTATION_ENABLED" = "host" ]; then
   if command -v dpkg > /dev/null; then
       debsums -c datadog-apm-inject
       debsums -c datadog-apm-library-all
@@ -144,7 +144,7 @@ else
   fi
 fi
 
-if [ -n "$DD_APM_LIBRARIES" ]; then
+if [ -n "$DD_APM_INSTRUMENTATION_LANGUAGES" ]; then
   if command -v dpkg > /dev/null; then
     debsums -c datadog-apm-library-all
     echo "[OK] Inject libraries installed"


### PR DESCRIPTION
- DD_APM_INSTRUMENTATION_ENABLED has 3 valid values: host, docker, and all. 
  - all is undocumented. 
  - host turn on host injection
  - docker turns on docker injection
    - it also disables agent installation
- DD_APM_LIBRARIES is now called DD_APM_INSTRUMENTATION_LANGUAGES
- DD_NO_CONFIG_CHANGE can be set to prevent any datadog.yaml changes (use it when updating an existing agent, so we don't break a customer's config file. They will have to make the changes by hand)
- Add enabling remote config to the datadog.yaml changes