### PR TITLE
Small fix to error handling while retrying dpkg lock issues

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -789,7 +789,7 @@ elif [ "$OS" = "Debian" ]; then
 
         if grep "Could not get lock" /tmp/ddog_install_error_msg; then
             RETRY_TIME=$((i*5))
-            printf "\033[31mInstallation failed: Unable to get lock.\nrRetrying in ${RETRY_TIME}s ($i/$MAX_RETRY_NB).\033[0m\n"
+            printf "\033[31mInstallation failed: Unable to get lock.\nRetrying in ${RETRY_TIME}s ($i/$MAX_RETRY_NB).\033[0m\n"
             sleep $RETRY_TIME
         elif [ $apt_exit_code -ne 0 ]; then
             cat /tmp/ddog_install_error_msg

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -782,9 +782,9 @@ elif [ "$OS" = "Debian" ]; then
             # if $sudo_cmd is empty, doing `$sudo_cmd X=Y command` fails with
             # `X=Y: command not found`; therefore we don't prefix the command with
             # $sudo_cmd at all in this case
-            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || (apt_exit_code=$? &&  cat /tmp/ddog_install_error_msg)
+            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || apt_exit_code=$?
         else
-            $sudo_cmd DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || (apt_exit_code=$? &&  cat /tmp/ddog_install_error_msg)
+            $sudo_cmd DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || apt_exit_code=$?
         fi
 
         if grep "Could not get lock" /tmp/ddog_install_error_msg; then
@@ -792,6 +792,7 @@ elif [ "$OS" = "Debian" ]; then
             printf "\033[31mInstallation failed: Unable to get lock.\nrRetrying in ${RETRY_TIME}s ($i/$MAX_RETRY_NB).\033[0m\n"
             sleep $RETRY_TIME
         elif [ $apt_exit_code -ne 0 ]; then
+            cat /tmp/ddog_install_error_msg
             exit $apt_exit_code
         else
             break

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -777,19 +777,22 @@ elif [ "$OS" = "Debian" ]; then
         $sudo_cmd apt-get update || printf "\033[31m'apt-get update' failed, the script will not install the latest version of apt-transport-https.\033[0m\n"
         # installing curl might trigger install of additional version of libssl; this will fail the installation process,
         # see https://unix.stackexchange.com/q/146283 for reference - we use DEBIAN_FRONTEND=noninteractive to fix that
+        apt_exit_code=0
         if [ -z "$sudo_cmd" ]; then
             # if $sudo_cmd is empty, doing `$sudo_cmd X=Y command` fails with
             # `X=Y: command not found`; therefore we don't prefix the command with
             # $sudo_cmd at all in this case
-            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || cat /tmp/ddog_install_error_msg
+            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || (apt_exit_code=$? &&  cat /tmp/ddog_install_error_msg)
         else
-            $sudo_cmd DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || cat /tmp/ddog_install_error_msg
+            $sudo_cmd DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || (apt_exit_code=$? &&  cat /tmp/ddog_install_error_msg)
         fi
 
         if grep "Could not get lock" /tmp/ddog_install_error_msg; then
             RETRY_TIME=$((i*5))
-            printf "\033[31mInstallation failed : Unable to get lock !!\nretrying in ${RETRY_TIME}s ($i/$MAX_RETRY_NB)\033[0m\n"
+            printf "\033[31mInstallation failed: Unable to get lock.\nrRetrying in ${RETRY_TIME}s ($i/$MAX_RETRY_NB).\033[0m\n"
             sleep $RETRY_TIME
+        elif [ $apt_exit_code -ne 0 ]; then
+            exit $apt_exit_code
         else
             break
         fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -769,7 +769,8 @@ if [ "$OS" = "RedHat" ]; then
 elif [ "$OS" = "Debian" ]; then
     apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
     apt_usr_share_keyring="/usr/share/keyrings/datadog-archive-keyring.gpg"
-
+    
+    DD_APT_INSTALL_ERROR_MSG=/tmp/ddog_install_error_msg
     MAX_RETRY_NB=10
     for i in $(seq 1 $MAX_RETRY_NB)
     do
@@ -782,17 +783,17 @@ elif [ "$OS" = "Debian" ]; then
             # if $sudo_cmd is empty, doing `$sudo_cmd X=Y command` fails with
             # `X=Y: command not found`; therefore we don't prefix the command with
             # $sudo_cmd at all in this case
-            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || apt_exit_code=$?
+            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>$DD_APT_INSTALL_ERROR_MSG  || apt_exit_code=$?
         else
-            $sudo_cmd DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>/tmp/ddog_install_error_msg || apt_exit_code=$?
+            $sudo_cmd DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>$DD_APT_INSTALL_ERROR_MSG || apt_exit_code=$?
         fi
 
-        if grep "Could not get lock" /tmp/ddog_install_error_msg; then
+        if grep "Could not get lock" $DD_APT_INSTALL_ERROR_MSG; then
             RETRY_TIME=$((i*5))
             printf "\033[31mInstallation failed: Unable to get lock.\nRetrying in ${RETRY_TIME}s ($i/$MAX_RETRY_NB).\033[0m\n"
             sleep $RETRY_TIME
         elif [ $apt_exit_code -ne 0 ]; then
-            cat /tmp/ddog_install_error_msg
+            cat $DD_APT_INSTALL_ERROR_MSG
             exit $apt_exit_code
         else
             break


### PR DESCRIPTION
Following #57, one ``apt-get install`` line is getting error suppressed when it shouldn't.