### PR TITLE
Fix conditional & add phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ post_release:
 
 tag:
 	$(eval CUR_VERSION=$(shell awk -F "=" '/^install_script_version=/{print $$NF}' install_script.sh.template))
-	ifneq(,$(findstring .post,$(CUR_VERSION)))
-		$(error "Please run make pre_release(_minor) first")
-	endif
+    ifneq (,$(findstring .post,$(CUR_VERSION)))
+	$(error "Please run make pre_release(_minor) first")
+    endif
 	git tag -as $(CUR_VERSION) -m $(CUR_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,5 @@ tag:
 	$(error "Please run make pre_release(_minor) first")
     endif
 	git tag -as $(CUR_VERSION) -m $(CUR_VERSION)
+
+.PHONY:	pre_release_minor update_changelog post_release tag


### PR DESCRIPTION
A makefile conditional can't be indented with tags, so this PR indents the conditional with spaces.
It also adds a missing phony target.

I probably changed something in my editor config and wrecked the tag rule after testing it, sorry about that.