### PR TITLE
Fix linux installer scripts

### DIFF
--- a/install_script_op_worker1.sh
+++ b/install_script_op_worker1.sh
@@ -424,7 +424,7 @@ see the logs above to determine the cause.
 If the failing repository is Datadog, please contact Datadog support.
 *****
 "
-    $sudo_cmd apt-get update -o Dir::Etc::sourcelist="sources.list.d/datadog.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+    $sudo_cmd apt-get update -o Dir::Etc::sourcelist="sources.list.d/datadog-observability-pipelines-worker.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
     ERROR_MESSAGE="ERROR
 Failed to install one or more packages, sometimes it may be
 due to another APT source failing. See the logs above to

--- a/test/dockertest.sh
+++ b/test/dockertest.sh
@@ -60,9 +60,9 @@ done
 [ -z "$SCRIPT" ] && echo "Please provide script file to test via -s/--script" && exit 1;
 [ -z "$IMAGE" ] && echo "Please provide image to test via -i/--image" && exit 1;
 
-if [ "$DD_OLD_SUSE" ]; then
+if [ "$DD_OLD_SUSE" == "true" ]; then
     ENTRYPOINT_PATH="/tmp/vol/test/old-suse-startup.sh"
-elif [ "$DD_OPW" ]; then
+elif [ "$DD_OPW" == "true" ]; then
     ENTRYPOINT_PATH="/tmp/vol/test/op-worker-test.sh"
 else
     ENTRYPOINT_PATH="/tmp/vol/test/localtest.sh"


### PR DESCRIPTION
- Fix conditionals for the ENTRYPOINT_PATH
- Correct the opw source to update

The entrypoint path was checking environment variables for presence, rather than true/false - while CI would always set a value for agent CI.

The op worker install script had updated the source file name, but failed to update the apt-get update command

amazonlinux:2023 was included in the op worker test matrix, but wasn't yet mirrored - this was resolved in https://github.com/DataDog/images/pull/4228
