### PR TITLE
[SLES11] migrating tests using third party dependency to internal image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,6 @@ generate-scripts:
       --minor-version "${MINOR_VERSION}"
       --expected-minor-version "${EXPECTED_MINOR_VERSION}"
       --flavor "${FLAVOR}"
-      --old-suse "${OLD_SUSE}"
       --apt-url "$APT_URL"
       --apt-repo-version "$APT_REPO_VERSION_AGENT6"
       --yum-url "$YUM_URL"
@@ -42,27 +41,10 @@ generate-scripts:
       --minor-version "${MINOR_VERSION}"
       --expected-minor-version "${EXPECTED_MINOR_VERSION}"
       --flavor "${FLAVOR}"
-      --old-suse "${OLD_SUSE}"
       --apt-url "$APT_URL"
       --apt-repo-version "$APT_REPO_VERSION_AGENT7"
       --yum-url "$YUM_URL"
       --yum-version-path "$YUM_VERSION_PATH_AGENT7"
-  variables:
-    OLD_SUSE: "false"
-
-test-opensuse-13:
-  extends: .test
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "push"'
-  parallel:
-    matrix:
-      - IMAGE: opensuse/archive:13.2
-      - IMAGE: opensuse/archive:13.2
-        FLAVOR: datadog-dogstatsd
-      - IMAGE: opensuse/archive:13.2
-        FLAVOR: datadog-iot-agent
-  variables:
-    OLD_SUSE: "true"
 
 test_pinned_version:
   extends: .test
@@ -130,6 +112,13 @@ test:
       - IMAGE: opensuse/leap:15.4
         FLAVOR: datadog-iot-agent
       - IMAGE: debian:12.1
+      - IMAGE: datadog/docker-library:install_script_sles_11
+      - IMAGE: datadog/docker-library:install_script_sles_11
+        FLAVOR: datadog-dogstatsd
+      - IMAGE: datadog/docker-library:install_script_sles_11
+        FLAVOR: datadog-iot-agent
+
+
 
 test-apm-injection:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64:$DATADOG_AGENT_BUILDIMAGES

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,10 +112,10 @@ test:
       - IMAGE: opensuse/leap:15.4
         FLAVOR: datadog-iot-agent
       - IMAGE: debian:12.1
-      - IMAGE: datadog/docker-library:install_script_sles_11
-      - IMAGE: datadog/docker-library:install_script_sles_11
+      - IMAGE: opensuse/archive:install_script_sles_11
+      - IMAGE: opensuse/archive:install_script_sles_11
         FLAVOR: datadog-dogstatsd
-      - IMAGE: datadog/docker-library:install_script_sles_11
+      - IMAGE: opensuse/archive:install_script_sles_11
         FLAVOR: datadog-iot-agent
 
 

--- a/test/dockertest.sh
+++ b/test/dockertest.sh
@@ -31,9 +31,6 @@ while [[ $# -gt 0 ]]; do
     --no-agent)
       DD_NO_AGENT_INSTALL="$2"
       ;;
-    --old-suse)
-      DD_OLD_SUSE="$2"
-      ;;
     --apt-url)
       TESTING_APT_URL="$2"
       ;;
@@ -63,9 +60,7 @@ done
 [ -z "$SCRIPT" ] && echo "Please provide script file to test via -s/--script" && exit 1;
 [ -z "$IMAGE" ] && echo "Please provide image to test via -i/--image" && exit 1;
 
-if [ "$DD_OLD_SUSE" == "true" ]; then
-    ENTRYPOINT_PATH="/tmp/vol/test/old-suse-startup.sh"
-elif [ "$DD_OPW" == "true" ]; then
+if [ "$DD_OPW" == "true" ]; then
     ENTRYPOINT_PATH="/tmp/vol/test/op-worker-test.sh"
 else
     ENTRYPOINT_PATH="/tmp/vol/test/localtest.sh"
@@ -82,7 +77,6 @@ docker run --rm --platform $PLATFORM -v $(pwd):/tmp/vol \
   -e DD_APM_INSTRUMENTATION_ENABLED="${DD_APM_INSTRUMENTATION_ENABLED}" \
   -e DD_NO_AGENT_INSTALL="$DD_NO_AGENT_INSTALL" \
   -e DD_APM_INSTRUMENTATION_LANGUAGES="${DD_APM_INSTRUMENTATION_LANGUAGES}" \
-  -e DD_OLD_SUSE="$DD_OLD_SUSE" \
   -e DD_OP_WORKER_MINOR_VERSION="${MINOR_VERSION}" \
   -e DD_OP_PIPELINE_ID=123 \
   -e DD_OPW_INSTALL_CLASSIC_AGENT=${DD_OPW_INSTALL_CLASSIC_AGENT}\

--- a/test/old-suse-startup.sh
+++ b/test/old-suse-startup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-echo "VERSION:11" > /etc/SuSE-release
-
-zypper install -y which 
-zypper addrepo https://ftp5.gwdg.de/pub/opensuse/discontinued/distribution/11.1/repo/oss/ discontinued
-zypper install --force -y bash=3.2-141.16
-
-bash -c "/tmp/vol/test/localtest.sh"


### PR DESCRIPTION
Migrated the previous image using an opensuse 13.2 with bash 3 downgraded using external dependency into an internal docker image getting rid of the external dependency. 