### PR TITLE
Show error summary when installation fails because of insufficient available disk space

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -172,6 +172,8 @@ function on_error() {
     printf "\033[31m$ERROR_MESSAGE
 It looks like you hit an issue when trying to install the $nice_flavor.
 
+    $ERR_SUMMARY
+
 Troubleshooting and basic usage information for the $nice_flavor are available at:
 
     https://docs.datadoghq.com/agent/basic_agent_usage/\n\033[0m\n"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -169,6 +169,7 @@ function on_error() {
 
     printf "\033[31m$ERROR_MESSAGE
 It looks like you hit an issue when trying to install the $nice_flavor.
+    
     $ERR_SUMMARY
 
 Troubleshooting and basic usage information for the $nice_flavor are available at:
@@ -772,8 +773,8 @@ if [ "$OS" == "RedHat" ]; then
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
     $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
-    cat "/tmp/ddog_install_error_msg"
-    ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg | echo "")
+    cat "/tmp/ddog_install_error_msg" || true
+    ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg || true)
 
 elif [ "$OS" == "Debian" ]; then
     apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
@@ -891,8 +892,8 @@ If the cause is unclear, please contact Datadog support.
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
     $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
-    cat "/tmp/ddog_install_error_msg"
-    ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg | echo "")
+    cat "/tmp/ddog_install_error_msg" || true
+    ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg || true)
 
     ERROR_MESSAGE=""
 elif [ "$OS" == "SUSE" ]; then
@@ -1040,13 +1041,13 @@ elif [ "$OS" == "SUSE" ]; then
 
   if [ -z "$sudo_cmd" ]; then
     ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>"/tmp/ddog_install_error_msg" ||:
-    cat "/tmp/ddog_install_error_msg"
+    cat "/tmp/ddog_install_error_msg" || true
   else
     $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>"/tmp/ddog_install_error_msg" ||:
-    cat "/tmp/ddog_install_error_msg"
+    cat "/tmp/ddog_install_error_msg" || true
   fi
 
-   ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg | echo "")
+   ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg || true)
 
   # If zypper fails to refresh a random repo, it installs the package, but then fails
   # anyway. Therefore we let it do its thing and then see if curl was installed or not.

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -774,7 +774,7 @@ if [ "$OS" == "RedHat" ]; then
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2>&1 | tee -a "/tmp/ddog_install_error_msg"
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2>"/tmp/ddog_install_error_msg";cat "/tmp/ddog_install_error_msg"
     ERR_SUMMARY=$(grep -oze "$ERROR_SUMMARY_REGEX" /tmp/ddog_install_error_msg)
 
 elif [ "$OS" == "Debian" ]; then
@@ -892,7 +892,7 @@ If the cause is unclear, please contact Datadog support.
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
-    $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2>&1 | tee -a "/tmp/ddog_install_error_msg"
+    $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2>"/tmp/ddog_install_error_msg";cat "/tmp/ddog_install_error_msg"
     ERR_SUMMARY=$(grep -oze "$ERROR_SUMMARY_REGEX" /tmp/ddog_install_error_msg)
 
     ERROR_MESSAGE=""
@@ -1040,9 +1040,11 @@ elif [ "$OS" == "SUSE" ]; then
   echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
   if [ -z "$sudo_cmd" ]; then
-    ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>&1 | tee -a "/tmp/ddog_install_error_msg" ||:
+    ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>"/tmp/ddog_install_error_msg" ||:
+    cat "/tmp/ddog_install_error_msg"
   else
-    $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>&1 | tee -a "/tmp/ddog_install_error_msg" ||:
+    $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>"/tmp/ddog_install_error_msg" ||:
+    cat "/tmp/ddog_install_error_msg"
   fi
 
    ERR_SUMMARY=$(grep -oze "$ERROR_SUMMARY_REGEX" /tmp/ddog_install_error_msg)

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -893,7 +893,7 @@ If the cause is unclear, please contact Datadog support.
 
     $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
     
-    ERR_SUMMARY=$(grep "No space left on device" -A1 -B1 /tmp/ddog_install_error_msg || true)
+    ERR_SUMMARY=$(grep "No space left on device" -C1 /tmp/ddog_install_error_msg || true)
 
     ERROR_MESSAGE=""
 elif [ "$OS" == "SUSE" ]; then
@@ -1045,7 +1045,7 @@ elif [ "$OS" == "SUSE" ]; then
     $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:
   fi
 
-   ERR_SUMMARY=$(grep "Write error" -A1 -B1 /tmp/ddog_install_error_msg || true)
+   ERR_SUMMARY=$(grep "Write error" -C1 /tmp/ddog_install_error_msg || true)
 
   # If zypper fails to refresh a random repo, it installs the package, but then fails
   # anyway. Therefore we let it do its thing and then see if curl was installed or not.

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -772,8 +772,8 @@ if [ "$OS" == "RedHat" ]; then
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
-    cat "/tmp/ddog_install_error_msg" || true
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" 2>"/tmp/ddog_install_error_msg" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
+    cat "/tmp/ddog_install_error_msg"
     ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg || true)
 
 elif [ "$OS" == "Debian" ]; then
@@ -892,7 +892,7 @@ If the cause is unclear, please contact Datadog support.
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
     $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
-    cat "/tmp/ddog_install_error_msg" || true
+    cat "/tmp/ddog_install_error_msg"
     ERR_SUMMARY=$(grep "No space left on device" -A1 -B1 /tmp/ddog_install_error_msg || true)
 
     ERROR_MESSAGE=""
@@ -1041,10 +1041,10 @@ elif [ "$OS" == "SUSE" ]; then
 
   if [ -z "$sudo_cmd" ]; then
     ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>"/tmp/ddog_install_error_msg" ||:
-    cat "/tmp/ddog_install_error_msg" || true
+    cat "/tmp/ddog_install_error_msg"
   else
     $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>"/tmp/ddog_install_error_msg" ||:
-    cat "/tmp/ddog_install_error_msg" || true
+    cat "/tmp/ddog_install_error_msg"
   fi
 
    ERR_SUMMARY=$(grep "Write error" -A1 -B1 /tmp/ddog_install_error_msg || true)

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -893,7 +893,7 @@ If the cause is unclear, please contact Datadog support.
 
     $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
     cat "/tmp/ddog_install_error_msg" || true
-    ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg || true)
+    ERR_SUMMARY=$(grep "No space left on device" -A1 -B1 /tmp/ddog_install_error_msg || true)
 
     ERROR_MESSAGE=""
 elif [ "$OS" == "SUSE" ]; then
@@ -1047,7 +1047,7 @@ elif [ "$OS" == "SUSE" ]; then
     cat "/tmp/ddog_install_error_msg" || true
   fi
 
-   ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg || true)
+   ERR_SUMMARY=$(grep "Write error" -A1 -B1 /tmp/ddog_install_error_msg || true)
 
   # If zypper fails to refresh a random repo, it installs the package, but then fails
   # anyway. Therefore we let it do its thing and then see if curl was installed or not.

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -41,8 +41,6 @@ UNSUPPORTED_PLATFORM_CODE=5
 INVALID_PARAMETERS_CODE=6
 UNABLE_TO_INSTALL_DEPENDENCY_CODE=7
 
-ERROR_SUMMARY_REGEX="Error Summary\n.*\n.*\n.*"
-
 # Set up a named pipe for logging
 npipe=/tmp/$$.tmp
 mknod $npipe p
@@ -171,7 +169,6 @@ function on_error() {
 
     printf "\033[31m$ERROR_MESSAGE
 It looks like you hit an issue when trying to install the $nice_flavor.
-
     $ERR_SUMMARY
 
 Troubleshooting and basic usage information for the $nice_flavor are available at:
@@ -774,8 +771,9 @@ if [ "$OS" == "RedHat" ]; then
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2>"/tmp/ddog_install_error_msg";cat "/tmp/ddog_install_error_msg"
-    ERR_SUMMARY=$(grep -oze "$ERROR_SUMMARY_REGEX" /tmp/ddog_install_error_msg)
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
+    cat "/tmp/ddog_install_error_msg"
+    ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg | echo "")
 
 elif [ "$OS" == "Debian" ]; then
     apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
@@ -892,8 +890,9 @@ If the cause is unclear, please contact Datadog support.
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
-    $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2>"/tmp/ddog_install_error_msg";cat "/tmp/ddog_install_error_msg"
-    ERR_SUMMARY=$(grep -oze "$ERROR_SUMMARY_REGEX" /tmp/ddog_install_error_msg)
+    $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
+    cat "/tmp/ddog_install_error_msg"
+    ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg | echo "")
 
     ERROR_MESSAGE=""
 elif [ "$OS" == "SUSE" ]; then
@@ -1047,7 +1046,7 @@ elif [ "$OS" == "SUSE" ]; then
     cat "/tmp/ddog_install_error_msg"
   fi
 
-   ERR_SUMMARY=$(grep -oze "$ERROR_SUMMARY_REGEX" /tmp/ddog_install_error_msg)
+   ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg | echo "")
 
   # If zypper fails to refresh a random repo, it installs the package, but then fails
   # anyway. Therefore we let it do its thing and then see if curl was installed or not.

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -41,6 +41,8 @@ UNSUPPORTED_PLATFORM_CODE=5
 INVALID_PARAMETERS_CODE=6
 UNABLE_TO_INSTALL_DEPENDENCY_CODE=7
 
+ERROR_SUMMARY_REGEX="Error Summary\n.*\n.*\n.*"
+
 # Set up a named pipe for logging
 npipe=/tmp/$$.tmp
 mknod $npipe p
@@ -770,7 +772,8 @@ if [ "$OS" == "RedHat" ]; then
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}"
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2>&1 | tee -a "/tmp/ddog_install_error_msg"
+    ERR_SUMMARY=$(grep -oze "$ERROR_SUMMARY_REGEX" /tmp/ddog_install_error_msg)
 
 elif [ "$OS" == "Debian" ]; then
     apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
@@ -887,7 +890,8 @@ If the cause is unclear, please contact Datadog support.
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
-    $sudo_cmd apt-get install -y --force-yes "${packages[@]}"
+    $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2>&1 | tee -a "/tmp/ddog_install_error_msg"
+    ERR_SUMMARY=$(grep -oze "$ERROR_SUMMARY_REGEX" /tmp/ddog_install_error_msg)
 
     ERROR_MESSAGE=""
 elif [ "$OS" == "SUSE" ]; then
@@ -1034,10 +1038,12 @@ elif [ "$OS" == "SUSE" ]; then
   echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
   if [ -z "$sudo_cmd" ]; then
-    ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" ||:
+    ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>&1 | tee -a "/tmp/ddog_install_error_msg" ||:
   else
-    $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" ||:
+    $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>&1 | tee -a "/tmp/ddog_install_error_msg" ||:
   fi
+
+   ERR_SUMMARY=$(grep -oze "$ERROR_SUMMARY_REGEX" /tmp/ddog_install_error_msg)
 
   # If zypper fails to refresh a random repo, it installs the package, but then fails
   # anyway. Therefore we let it do its thing and then see if curl was installed or not.

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -772,8 +772,8 @@ if [ "$OS" == "RedHat" ]; then
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" 2>"/tmp/ddog_install_error_msg" || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
-    cat "/tmp/ddog_install_error_msg"
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
+    
     ERR_SUMMARY=$(grep "Error Summary" -A3 /tmp/ddog_install_error_msg || true)
 
 elif [ "$OS" == "Debian" ]; then
@@ -891,8 +891,8 @@ If the cause is unclear, please contact Datadog support.
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
-    $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2>"/tmp/ddog_install_error_msg"
-    cat "/tmp/ddog_install_error_msg"
+    $sudo_cmd apt-get install -y --force-yes "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
+    
     ERR_SUMMARY=$(grep "No space left on device" -A1 -B1 /tmp/ddog_install_error_msg || true)
 
     ERROR_MESSAGE=""
@@ -1040,11 +1040,9 @@ elif [ "$OS" == "SUSE" ]; then
   echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
   if [ -z "$sudo_cmd" ]; then
-    ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>"/tmp/ddog_install_error_msg" ||:
-    cat "/tmp/ddog_install_error_msg"
+    ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:
   else
-    $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2>"/tmp/ddog_install_error_msg" ||:
-    cat "/tmp/ddog_install_error_msg"
+    $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:
   fi
 
    ERR_SUMMARY=$(grep "Write error" -A1 -B1 /tmp/ddog_install_error_msg || true)


### PR DESCRIPTION
Grep specific part of the system's package manager error output to display them at the end to increase visibility when an installation fails because of insufficient available space.