### PR TITLE
Prepare release 1.22.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,11 @@
 Release Notes
 =============
 
-Unreleased
+1.22.0
 ================
+
+- Allow installation of arm64 FIPS Proxy packages (#83)
+- Show error summary when installation fails because of insufficient available disk space (#92)
 
 1.21.0
 ================

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -9,7 +9,7 @@ set -e
 
 DEPRECATION_MESSAGE_PLACEHOLDER
 
-install_script_version=1.21.0.post
+install_script_version=1.22.0
 logfile="ddagent-install.log"
 support_email=support@datadoghq.com
 variant=install_scriptINSTALL_INFO_VERSION_PLACEHOLDER

--- a/install_script_op_worker1.sh
+++ b/install_script_op_worker1.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-install_script_version=1.21.0.post
+install_script_version=1.22.0
 logfile="dd-install.log"
 support_email=support@datadoghq.com
 variant=install_script_op_worker1


### PR DESCRIPTION
New release for fips proxy
QA test:
```
inv create-vm --no-install-agent -r arm64
```
then
```
ubuntu@ip-10-1-59-175:~$ uname -m
aarch64
ubuntu@ip-10-1-59-175:~$ DD_API_KEY=XXX DD_FIPS_MODE="True" DD_SITE="datadoghq.com" DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 45377  100 45377    0     0   391k      0 --:--:-- --:--:-- --:--:--  392k

* Datadog Agent 7 install script v1.21.0

FIPS mode isn't available for your architecture
Unable to send telemetry
```
then with modified script
```
ubuntu@ip-10-1-59-175:~$ DD_API_KEY=XXX DD_FIPS_MODE="True" DD_SITE="datadoghq.com" DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(cat install_script_agent7.sh)"

* Datadog Agent 7 install script v1.22.0


* Installing apt-transport-https, curl and gnupg

Hit:1 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy InRelease
Get:2 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy-updates InRelease [119 kB]
Get:3 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy-backports InRelease [109 kB]
Get:4 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease [110 kB]
Get:5 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy/universe arm64 Packages [13.9 MB]
Get:6 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy/universe Translation-en [5652 kB]
Get:7 http://ports.ubuntu.com/ubuntu-ports jammy-security/main arm64 Packages [695 kB]
Get:8 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy/universe arm64 c-n-f Metadata [277 kB]
Get:9 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy/multiverse arm64 Packages [184 kB]
Get:10 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy/multiverse Translation-en [112 kB]
Get:11 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy/multiverse arm64 c-n-f Metadata [7064 B]
Get:12 http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports jammy-updates/main arm64 Packages [899 kB]
etc
```