### PR TITLE
[e2e] part 2 refactoring

### DIFF
--- a/test/e2e/agentflavor.go
+++ b/test/e2e/agentflavor.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package e2e
+
+import "fmt"
+
+type agentFlavor string
+
+func (af *agentFlavor) String() string {
+	return string(*af)
+}
+
+func (af *agentFlavor) Set(value string) error {
+	if len(*af) > 0 {
+		return fmt.Errorf("flavor flag already set to %s while trying to set to %s", *af, value)
+	}
+	*af = agentFlavor(value)
+	return nil
+}
+
+const (
+	agentFlavorDatadogAgent     agentFlavor = "datadog-agent"
+	agentFlavorDatadogIOTAgent  agentFlavor = "datadog-iot-agent"
+	agentFlavorDatadogDogstatsd agentFlavor = "datadog-dogstatsd"
+)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -103,3 +103,79 @@ func (s *linuxInstallerTestSuite) addExtraIntegration() {
 	assert.NoError(t, err, "integration install failed")
 	_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch /opt/%s/embedded/lib/python3.9/site-packages/testfile", s.baseName))
 }
+
+func (s *linuxInstallerTestSuite) uninstallAndAssert() {
+	t := s.T()
+	vm := s.Env().VM
+	t.Logf("Remove %s", flavor)
+	if _, err := vm.ExecuteWithError("command -v apt"); err == nil {
+		t.Log("Uninstall with apt")
+		vm.Execute(fmt.Sprintf("sudo apt remove -y %s", flavor))
+		// dd-agent user and config file should still be here
+		_, err := vm.ExecuteWithError("id dd-agent")
+		assert.NoError(t, err, "user datadog-agent not present after apt remove")
+		_, err = vm.ExecuteWithError(fmt.Sprintf("stat /etc/%s/%s", s.baseName, s.configFile))
+		assert.NoError(t, err, fmt.Sprintf("/etc/%s/%s absent after apt remove", s.baseName, s.configFile))
+		if flavor == "datadog-agent" {
+			// The custom file should still be here. All other files, including the extra integration, should be removed
+			_, err = vm.ExecuteWithError("stat /opt/datadog-agent/embedded/lib/python3.9/site-packages/testfile")
+			assert.NoError(t, err, "testfile absent after apt remove")
+			files := strings.Split(strings.TrimSuffix(vm.Execute("find /opt/datadog-agent -type f"), "\n"), "\n")
+			assert.Len(t, files, 1, fmt.Sprintf("/opt/datadog-agent present after apt remove, found %v", files))
+		} else {
+			// All files in /opt/datadog-agent should be removed
+			_, err = vm.ExecuteWithError(fmt.Sprintf("stat /opt/%s", s.baseName))
+			assert.Error(t, err, fmt.Sprintf("/opt/%s present after apt remove", s.baseName))
+		}
+		if !noFlush {
+			t.Log("Purge package")
+			vm.Execute(fmt.Sprintf("sudo apt remove --purge -y %s", flavor))
+			_, err := vm.ExecuteWithError("id datadog-agent")
+			assert.Error(t, err, "dd-agent present after %s purge")
+			_, err = vm.ExecuteWithError(fmt.Sprintf("stat /etc/%s", s.baseName))
+			assert.Error(t, err, fmt.Sprintf("stat /etc/%s present after apt purge", s.baseName))
+			_, err = vm.ExecuteWithError(fmt.Sprintf("stat /opt/%s", s.baseName))
+			assert.Error(t, err, fmt.Sprintf("stat /opt/%s present after apt purge", s.baseName))
+		}
+	} else if _, err = vm.ExecuteWithError("command -v yum"); err == nil {
+		t.Log("Uninstall with yum")
+		vm.Execute(fmt.Sprintf("sudo yum remove -y %s", flavor))
+		// dd-agent user and config file should still be here
+		_, err := vm.ExecuteWithError("id dd-agent")
+		assert.NoError(t, err, "user datadog-agent not present after yum remove")
+		_, err = vm.ExecuteWithError(fmt.Sprintf("stat /etc/%s/%s", s.baseName, s.configFile))
+		assert.NoError(t, err, fmt.Sprintf("/etc/%s/%s absent after yum remove", s.baseName, s.configFile))
+		if flavor == "datadog-agent" {
+			// The custom file should still be here. All other files, including the extra integration, should be removed
+			_, err = vm.ExecuteWithError("stat /opt/datadog-agent/embedded/lib/python3.9/site-packages/testfile")
+			assert.NoError(t, err, "testfile absent after yum remove")
+			files := strings.Split(strings.TrimSuffix(vm.Execute("find /opt/datadog-agent -type f"), "\n"), "\n")
+			assert.Len(t, files, 1, fmt.Sprintf("/opt/datadog-agent present after yum remove, found %v", files))
+		} else {
+			// All files in /opt/datadog-agent should be removed
+			_, err = vm.ExecuteWithError(fmt.Sprintf("stat /opt/%s", s.baseName))
+			assert.Error(t, err, fmt.Sprintf("/opt/%s present after yum remove", s.baseName))
+		}
+	} else if _, err = vm.ExecuteWithError("command -v zypper"); err == nil {
+		t.Log("Uninstall with zypper")
+		vm.Execute(fmt.Sprintf("sudo zypper remove -y %s", flavor))
+		//	# dd-agent user and config file should still be here
+		_, err := vm.ExecuteWithError("id dd-agent")
+		assert.NoError(t, err, "user datadog-agent not present after zypper remove")
+		_, err = vm.ExecuteWithError(fmt.Sprintf("stat /etc/%s/%s", s.baseName, s.configFile))
+		assert.NoError(t, err, fmt.Sprintf("/etc/%s/%s absent after zypper remove", s.baseName, s.configFile))
+		if flavor == "datadog-agent" {
+			// The custom file should still be here. All other files, including the extra integration, should be removed
+			_, err = vm.ExecuteWithError("stat /opt/datadog-agent/embedded/lib/python3.9/site-packages/testfile")
+			assert.NoError(t, err, "testfile absent after zypper remove")
+			files := strings.Split(strings.TrimSuffix(vm.Execute("find /opt/datadog-agent -type f"), "\n"), "\n")
+			assert.Len(t, files, 1, fmt.Sprintf("/opt/datadog-agent present after zypper remove, found %v", files))
+		} else {
+			// All files in /opt/datadog-agent should be removed
+			_, err = vm.ExecuteWithError(fmt.Sprintf("stat /opt/%s", s.baseName))
+			assert.Error(t, err, fmt.Sprintf("/opt/%s present after zypper remove", s.baseName))
+		}
+	} else {
+		assert.FailNow(t, "Unknown package manager")
+	}
+}

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -9,8 +9,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -60,4 +62,44 @@ func (s *linuxInstallerTestSuite) SetupSuite() {
 	}
 	s.baseName = baseNameByFlavor[flavor]
 	s.configFile = configFileByFlavor[flavor]
+}
+
+func (s *linuxInstallerTestSuite) assertInstallScript() {
+	t := s.T()
+	vm := s.Env().VM
+	t.Log("Check user, config file and service")
+	// check presence of the dd-agent user
+	_, err := vm.ExecuteWithError("id dd-agent")
+	assert.NoError(t, err, "user datadog-agent does not exist after install")
+	// Check presence of the config file - the file is added by the install script, so this should always be okay
+	// if the install succeeds
+	_, err = vm.ExecuteWithError(fmt.Sprintf("stat /etc/%s/%s", s.baseName, s.configFile))
+	assert.NoError(t, err, fmt.Sprintf("config file /etc/%s/%s does not exist after install", s.baseName, s.configFile))
+	// Check presence and ownership of the config and main directories
+	owner := strings.TrimSuffix(vm.Execute(fmt.Sprintf("stat -c \"%%U\" /etc/%s/", s.baseName)), "\n")
+	assert.Equal(t, "dd-agent", owner, fmt.Sprintf("dd-agent does not own /etc/%s", s.baseName))
+	owner = strings.TrimSuffix(vm.Execute(fmt.Sprintf("stat -c \"%%U\" /opt/%s/", s.baseName)), "\n")
+	assert.Equal(t, "dd-agent", owner, fmt.Sprintf("dd-agent does not own /opt/%s", s.baseName))
+	// Check that the service is active
+	if _, err = vm.ExecuteWithError("command -v systemctl"); err == nil {
+		_, err = vm.ExecuteWithError(fmt.Sprintf("systemctl is-active %s", s.baseName))
+		assert.NoError(t, err, fmt.Sprintf("%s not running after Agent install", s.baseName))
+	} else if _, err = vm.ExecuteWithError("command -v initctl"); err == nil {
+		status := strings.TrimSuffix(vm.Execute(fmt.Sprintf("sudo status %s", s.baseName)), "\n")
+		assert.Contains(t, "running", status, fmt.Sprintf("%s not running after Agent install", s.baseName))
+	} else {
+		assert.FailNow(t, "Unknown service manager")
+	}
+}
+
+func (s *linuxInstallerTestSuite) addExtraIntegration() {
+	t := s.T()
+	if flavor != "datadog-agent" {
+		t.Skip()
+	}
+	vm := s.Env().VM
+	t.Log("Install an extra integration, and create a custom file")
+	_, err := vm.ExecuteWithError("sudo -u dd-agent -- datadog-agent integration install -t datadog-bind9==0.1.0")
+	assert.NoError(t, err, "integration install failed")
+	_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch /opt/%s/embedded/lib/python3.9/site-packages/testfile", s.baseName))
 }

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+)
+
+const (
+	defaultScriptURL = "https://s3.amazonaws.com/dd-agent/scripts"
+)
+
+var (
+	flavor    string // datadog-agent, datadog-iot-agent, datadog-dogstatsd
+	mode      string // install, upgrade5, upgrade6, upgrade7
+	apiKey    string // Needs to be valid, at least for the upgrade5 scenario
+	scriptURL string // To test a non-published script
+	noFlush   bool   // To prevent eventual cleanup, to test install_script won't override existing configuration
+)
+
+// note: no need to call flag.Parse() on test code, go test does it
+func init() {
+	flag.StringVar(&flavor, "flavor", "datadog-agent", "defines agent install flavor")
+	flag.StringVar(&mode, "mode", "install", "test mode")
+	flag.BoolVar(&noFlush, "noFlush", false, "To prevent eventual cleanup, to test install_script won't override existing configuration")
+	flag.StringVar(&apiKey, "apiKey", os.Getenv("DD_API_KEY"), "Datadog API key")
+	flag.StringVar(&scriptURL, "scriptURL", defaultScriptURL, fmt.Sprintf("Defines the script URL, default %s", defaultScriptURL))
+}
+
+type linuxInstallerTestSuite struct {
+	e2e.Suite[e2e.VMEnv]
+}

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -145,7 +145,7 @@ func (s *linuxInstallerTestSuite) assertUninstall() {
 	}
 }
 
-func (s *linuxInstallerTestSuite) flush() {
+func (s *linuxInstallerTestSuite) purge() {
 	t := s.T()
 	vm := s.Env().VM
 
@@ -161,7 +161,7 @@ func (s *linuxInstallerTestSuite) flush() {
 	vm.Execute(fmt.Sprintf("sudo apt remove --purge -y %s", flavor))
 }
 
-func (s *linuxInstallerTestSuite) assertFlush() {
+func (s *linuxInstallerTestSuite) assertPurge() {
 	t := s.T()
 	vm := s.Env().VM
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -19,11 +19,23 @@ const (
 )
 
 var (
+	// flags
 	flavor    agentFlavor // datadog-agent, datadog-iot-agent, datadog-dogstatsd
 	mode      string      // install, upgrade5, upgrade6, upgrade7
 	apiKey    string      // Needs to be valid, at least for the upgrade5 scenario
 	scriptURL string      // To test a non-published script
 	noFlush   bool        // To prevent eventual cleanup, to test install_script won't override existing configuration
+
+	baseNameByFlavor = map[agentFlavor]string{
+		agentFlavorDatadogAgent:     "datadog-agent",
+		agentFlavorDatadogDogstatsd: "datadog-dogstatsd",
+		agentFlavorDatadogIOTAgent:  "datadog-agent",
+	}
+	configFileByFlavor = map[agentFlavor]string{
+		agentFlavorDatadogAgent:     "datadog.yaml",
+		agentFlavorDatadogDogstatsd: "dogstatsd.yaml",
+		agentFlavorDatadogIOTAgent:  "datadog.yaml",
+	}
 )
 
 // note: no need to call flag.Parse() on test code, go test does it
@@ -37,6 +49,8 @@ func init() {
 
 type linuxInstallerTestSuite struct {
 	e2e.Suite[e2e.VMEnv]
+	baseName   string
+	configFile string
 }
 
 func (s *linuxInstallerTestSuite) SetupSuite() {
@@ -44,4 +58,6 @@ func (s *linuxInstallerTestSuite) SetupSuite() {
 		s.T().Log("setting default agent flavor")
 		flavor = defaultAgentFlavor
 	}
+	s.baseName = baseNameByFlavor[flavor]
+	s.configFile = configFileByFlavor[flavor]
 }

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -182,7 +182,7 @@ func (s *linuxInstallerTestSuite) assertUninstall() {
 	}
 }
 
-func (s *linuxInstallerTestSuite) flushAndAssert() {
+func (s *linuxInstallerTestSuite) flush() {
 	t := s.T()
 	vm := s.Env().VM
 
@@ -196,6 +196,21 @@ func (s *linuxInstallerTestSuite) flushAndAssert() {
 
 	t.Log("Purge package")
 	vm.Execute(fmt.Sprintf("sudo apt remove --purge -y %s", flavor))
+}
+
+func (s *linuxInstallerTestSuite) assertFlush() {
+	t := s.T()
+	vm := s.Env().VM
+
+	if noFlush {
+		t.Skip()
+	}
+
+	if _, err := vm.ExecuteWithError("command -v apt"); err != nil {
+		t.Skip()
+	}
+
+	t.Log("Assert purge package")
 	_, err := vm.ExecuteWithError("id datadog-agent")
 	assert.Error(t, err, "dd-agent present after %s purge")
 	_, err = vm.ExecuteWithError(fmt.Sprintf("stat /etc/%s", s.baseName))

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -14,20 +14,21 @@ import (
 )
 
 const (
-	defaultScriptURL = "https://s3.amazonaws.com/dd-agent/scripts"
+	defaultScriptURL               = "https://s3.amazonaws.com/dd-agent/scripts"
+	defaultAgentFlavor agentFlavor = agentFlavorDatadogAgent
 )
 
 var (
-	flavor    string // datadog-agent, datadog-iot-agent, datadog-dogstatsd
-	mode      string // install, upgrade5, upgrade6, upgrade7
-	apiKey    string // Needs to be valid, at least for the upgrade5 scenario
-	scriptURL string // To test a non-published script
-	noFlush   bool   // To prevent eventual cleanup, to test install_script won't override existing configuration
+	flavor    agentFlavor // datadog-agent, datadog-iot-agent, datadog-dogstatsd
+	mode      string      // install, upgrade5, upgrade6, upgrade7
+	apiKey    string      // Needs to be valid, at least for the upgrade5 scenario
+	scriptURL string      // To test a non-published script
+	noFlush   bool        // To prevent eventual cleanup, to test install_script won't override existing configuration
 )
 
 // note: no need to call flag.Parse() on test code, go test does it
 func init() {
-	flag.StringVar(&flavor, "flavor", "datadog-agent", "defines agent install flavor")
+	flag.Var(&flavor, "flavor", "defines agent install flavor, supported values are [datadog-agent, datadog-iot-agent, datadog-dogstatsd]")
 	flag.StringVar(&mode, "mode", "install", "test mode")
 	flag.BoolVar(&noFlush, "noFlush", false, "To prevent eventual cleanup, to test install_script won't override existing configuration")
 	flag.StringVar(&apiKey, "apiKey", os.Getenv("DD_API_KEY"), "Datadog API key")
@@ -36,4 +37,11 @@ func init() {
 
 type linuxInstallerTestSuite struct {
 	e2e.Suite[e2e.VMEnv]
+}
+
+func (s *linuxInstallerTestSuite) SetupSuite() {
+	if flavor == "" {
+		s.T().Log("setting default agent flavor")
+		flavor = defaultAgentFlavor
+	}
 }

--- a/test/e2e/doc.go
+++ b/test/e2e/doc.go
@@ -3,4 +3,5 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package e2e implements e2e tests for the agent linux installer
 package e2e

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -74,7 +74,7 @@ func (s *linuxInstallerTestSuite) TestInstallerScript() {
 
 	s.assertUninstall()
 
-	s.flush()
+	s.purge()
 
-	s.assertFlush()
+	s.assertPurge()
 }

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -73,4 +73,6 @@ func (s *linuxInstallerTestSuite) TestInstallerScript() {
 	s.uninstall()
 
 	s.assertUninstall()
+
+	s.flushAndAssert()
 }

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -74,5 +74,7 @@ func (s *linuxInstallerTestSuite) TestInstallerScript() {
 
 	s.assertUninstall()
 
-	s.flushAndAssert()
+	s.flush()
+
+	s.assertFlush()
 }

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -70,5 +70,7 @@ func (s *linuxInstallerTestSuite) TestInstallerScript() {
 
 	s.addExtraIntegration()
 
-	s.uninstallAndAssert()
+	s.uninstall()
+
+	s.assertUninstall()
 }

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -6,9 +6,7 @@
 package e2e
 
 import (
-	"flag"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -18,31 +16,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
 	"github.com/stretchr/testify/assert"
 )
-
-const (
-	defaultScriptURL = "https://s3.amazonaws.com/dd-agent/scripts"
-)
-
-var (
-	flavor    string // datadog-agent, datadog-iot-agent, datadog-dogstatsd
-	mode      string // install, upgrade5, upgrade6, upgrade7
-	apiKey    string // Needs to be valid, at least for the upgrade5 scenario
-	scriptURL string // To test a non-published script
-	noFlush   bool   // To prevent eventual cleanup, to test install_script won't override existing configuration
-)
-
-// note: no need to call flag.Parse() on test code, go test does it
-func init() {
-	flag.StringVar(&flavor, "flavor", "datadog-agent", "defines agent install flavor")
-	flag.StringVar(&mode, "mode", "install", "test mode")
-	flag.BoolVar(&noFlush, "noFlush", false, "To prevent eventual cleanup, to test install_script won't override existing configuration")
-	flag.StringVar(&apiKey, "apiKey", os.Getenv("DD_API_KEY"), "Datadog API key")
-	flag.StringVar(&scriptURL, "scriptURL", defaultScriptURL, fmt.Sprintf("Defines the script URL, default %s", defaultScriptURL))
-}
-
-type linuxInstallerTestSuite struct {
-	e2e.Suite[e2e.VMEnv]
-}
 
 func TestLinuxInstallerSuite(t *testing.T) {
 	scriptType := "production"


### PR DESCRIPTION
Refactoring previous PR that added e2e tests for the installer script.

In this iteration no feature is added, only refactoring code to move common code.

Best reviewed per commit to follow the refactoring.

Next iteration will add one file per mode, and will add two new modes: fips and maximal install, with different assertions - you can see the next iteration in https://github.com/DataDog/agent-linux-install-script/pull/98/files#diff-89059d4760ebc9a893c31db5ec0d36a1305d6e1d82ad43b4d8331e97b8e6552b