### PR TITLE
[ci] allow running e2e tests with custom script url

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,7 +225,7 @@ e2e:
     # Use S3 backend
     - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
   script:
-    - cd test/e2e && gotestsum --format standard-verbose --junitfile "junit-${CI_JOB_NAME}.xml" -- -timeout 0s . -v --flavor ${FLAVOR} --platform ${PLATFORM} ${EXTRA_PARAMS}
+    - cd test/e2e && gotestsum --format standard-verbose --junitfile "junit-${CI_JOB_NAME}.xml" -- -timeout 0s . -v --flavor ${FLAVOR} --platform ${PLATFORM} --scriptURL ${SCRIPT_URL}  ${EXTRA_PARAMS}
   rules:
     - if: $CI_COMMIT_TAG
       when: always
@@ -238,6 +238,7 @@ e2e:
     E2E_PRIVATE_KEY_PATH: /tmp/agent-qa-ssh-key
     E2E_KEY_PAIR_NAME: ci.agent-linux-install-script
     TEAM: agent-platform
+    SCRIPT_URL: https://s3.amazonaws.com/dd-agent/scripts
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
@@ -10,7 +7,7 @@
       "request": "launch",
       "mode": "auto",
       "program": "${fileDirname}",
-      "args": ["-flavor", "datadog-agent", "-targetPlatform", "Ubuntu_22.04"]
+      "args": ["-flavor", "datadog-agent", "-platform", "Ubuntu_22.04"]
     }
   ]
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -2,22 +2,26 @@
 
 These are e2e tests for the install script. They create a remote VM on AWS using [e2e test framework](https://pkg.go.dev/github.com/DataDog/datadog-agent/test/new-e2e@main/pkg/utils/e2e) and run the installer script with:
 
-* 4 possible modes:
-  * `install` install latest Agent 7 RC 
-  * `upgrade5` install Agent 5 and upgrade to latest Agent 7 RC
-  * `upgrade6` install Agent 6 and upgrade to latest Agent 7 RC
-  * `upgrade7` install latest stable Agent 7 and upgrade to latest Agent 7 RC
-* 3 possible flavors:
-  * `datadog-agent` install Datadog Agent
-  * `datadog-iot-agent` install Datadog IoT Agent
-  * `datadog-dogstatsd` install Datadog dogstatsd
+- 4 possible modes:
+  - `install` install latest Agent 7 RC
+  - `upgrade5` install Agent 5 and upgrade to latest Agent 7 RC
+  - `upgrade6` install Agent 6 and upgrade to latest Agent 7 RC
+  - `upgrade7` install latest stable Agent 7 and upgrade to latest Agent 7 RC
+- 3 possible flavors:
+  - `datadog-agent` install Datadog Agent
+  - `datadog-iot-agent` install Datadog IoT Agent
+  - `datadog-dogstatsd` install Datadog dogstatsd
 
 ## Run locally
 
 Use `go test` to run tests locally, from a shell wrapped in a valid aws session. This currently supports Datadog internal only configurations.
 
-### Example: run mode install, flavor datadog-agent
+### Example: run install test, flavor datadog-agent, platform Amazon 2023
 
 ```shell
-cd test/e2e && go test -timeout 0s . -v --flavor datadog-agent --mode install
+cd test/e2e && go test -timeout 0s . -v --run TestInstallSuite --flavor datadog-agent --platform Amazon_Linux_2023
 ```
+
+## Run on CI
+
+Manually run `e2e` stage on the CI and then manually upload results to CI Visibility running `e2e_test_upload` stage. You can override the script url setting `SCRIPT_URL` variable on manual test trigger


### PR DESCRIPTION
Run e2e tests with custom script url overriding SCRIPT_URL variable in manual tests execution

Update documentation