### PR TITLE
remove datadog-apm-library-all

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -434,7 +434,7 @@ if [ -n "$DD_APM_INSTRUMENTATION_LANGUAGES" ]; then
   do
     case $lib in
       all)
-        apm_libraries+=("datadog-apm-library-all")
+        apm_libraries+=("datadog-apm-library-java" "datadog-apm-library-js" "datadog-apm-library-python" "datadog-apm-library-dotnet" "datadog-apm-library-ruby")
         ;;
       java)
         apm_libraries+=("datadog-apm-library-java")
@@ -462,7 +462,7 @@ if [ -n "$DD_APM_INSTRUMENTATION_LANGUAGES" ]; then
   done
 elif [ -n "$host_injection_enabled" ] || [ -n "$docker_injection_enabled" ]; then
   # Default to all libraries if injection is enabled
-  apm_libraries+=("datadog-apm-library-all")
+  apm_libraries+=("datadog-apm-library-java" "datadog-apm-library-js" "datadog-apm-library-python" "datadog-apm-library-dotnet" "datadog-apm-library-ruby")
 fi
 
 no_config_change=

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -215,7 +215,6 @@ if [ -n "$DD_APM_INSTRUMENTATION_LANGUAGES" ]; then
     debsums -c datadog-apm-library-ruby
     echo "[OK] Inject libraries installed"
   else
-    rpm --verify --nomode --nouser --nogroup datadog-apm-inject
     rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
     rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
     rpm --verify --nomode --nouser --nogroup datadog-apm-library-js

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -170,11 +170,19 @@ fi
 if [ -n "$DD_APM_INSTRUMENTATION_ENABLED" ] || [ "${SCRIPT_FLAVOR}" == "docker_injection" ]; then
   if [[ "$OS_TYPE" == "ubuntu" ]]; then
       debsums -c datadog-apm-inject
-      debsums -c datadog-apm-library-all
+      debsums -c datadog-apm-library-dotnet
+      debsums -c datadog-apm-library-java
+      debsums -c datadog-apm-library-js
+      debsums -c datadog-apm-library-python
+      debsums -c datadog-apm-library-ruby
       echo "[OK] Inject libraries installed"
   else
       rpm --verify --nomode --nouser --nogroup datadog-apm-inject
-      rpm --verify --nomode --nouser --nogroup datadog-apm-library-all
+      rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
+      rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
+      rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
+      rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
+      rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
       echo "[OK] Inject libraries installed"
   fi
 
@@ -200,10 +208,19 @@ fi
 
 if [ -n "$DD_APM_INSTRUMENTATION_LANGUAGES" ]; then
   if [[ "$OS_TYPE" == "ubuntu" ]]; then
-    debsums -c datadog-apm-library-all
+    debsums -c datadog-apm-library-dotnet
+    debsums -c datadog-apm-library-java
+    debsums -c datadog-apm-library-js
+    debsums -c datadog-apm-library-python
+    debsums -c datadog-apm-library-ruby
     echo "[OK] Inject libraries installed"
   else
-    rpm --verify --nomode --nouser --nogroup datadog-apm-library-all
+    rpm --verify --nomode --nouser --nogroup datadog-apm-inject
+    rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
+    rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
+    rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
+    rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
+    rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
     echo "[OK] Inject libraries installed"
   fi
 fi


### PR DESCRIPTION
Do not use datadog-apm-library-all to install every tracing library, because it doesn't allow us to easily force an upgrade to the latest version.