### PR TITLE
CI: simplify test matrices

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,25 +65,18 @@ test_pinned_version:
   extends: .test
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
+  variables:
+    MINOR_VERSION: 38
   parallel:
     # NOTE: to keep the matrix reasonably sized, we don't test everything everywhere
     # for example, it's ok to test getting specific flavor/minor version only on
     # CentOS 7 (yum) and Rocky 9 (dnf) and not on all versions of all RHEL derivatives
     matrix:
-      - IMAGE: centos:centos7
-        MINOR_VERSION: 38
-      - IMAGE: rockylinux:9.0
-        MINOR_VERSION: 38
-      - IMAGE: ubuntu:14.04
-        MINOR_VERSION: 38
-      - IMAGE: debian:10.9
-        MINOR_VERSION: 38
       # When installing pinned minor version and some repos are broken,
       # `zypper search` used will fail. We need to figure out a fix for this.
       #- IMAGE: opensuse/archive:42.3
       #  MINOR_VERSION: 38
-      - IMAGE: opensuse/leap:15.4
-        MINOR_VERSION: 38
+      - IMAGE: [centos:centos7, rockylinux:9.0, ubuntu:14.04, debian:10.9, opensuse/leap:15.4]
 
 # Opensuse13 only supports Datadog Agent version up 6.32, hence these tests should not be launched on pipelines triggered by datadog-agent pipelines
 test_opensuse13:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,10 +93,7 @@ test_opensuse13:
   parallel:
     matrix:
       - IMAGE: opensuse/archive:install_script_sles_11
-      - IMAGE: opensuse/archive:install_script_sles_11
-        FLAVOR: datadog-dogstatsd
-      - IMAGE: opensuse/archive:install_script_sles_11
-        FLAVOR: datadog-iot-agent
+        FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
 
 test:
   extends: .test
@@ -106,39 +103,20 @@ test:
     # CentOS 7 (yum) and Rocky 9 (dnf) and not on all versions of all RHEL derivatives
     matrix:
       - IMAGE: centos:centos7
-      - IMAGE: centos:centos7
-        FLAVOR: datadog-dogstatsd
-      - IMAGE: centos:centos7
-        FLAVOR: datadog-iot-agent
+        FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
       - IMAGE: rockylinux:9.0
-      - IMAGE: rockylinux:9.0
-        FLAVOR: datadog-dogstatsd
-      - IMAGE: rockylinux:9.0
-        FLAVOR: datadog-iot-agent
+        FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
       - IMAGE: amazonlinux:2
       - IMAGE: amazonlinux:2022
       - IMAGE: ubuntu:14.04
-      - IMAGE: ubuntu:14.04
-        FLAVOR: datadog-dogstatsd
-      - IMAGE: ubuntu:14.04
-        FLAVOR: datadog-iot-agent
+        FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
       - IMAGE: debian:10.9
-      - IMAGE: debian:10.9
-        FLAVOR: datadog-dogstatsd
-      - IMAGE: debian:10.9
-        FLAVOR: datadog-iot-agent
-      - IMAGE: ubuntu:14.04
+        FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
       - IMAGE: ubuntu:22.04
       - IMAGE: opensuse/archive:42.3
-      - IMAGE: opensuse/archive:42.3
-        FLAVOR: datadog-dogstatsd
-      - IMAGE: opensuse/archive:42.3
-        FLAVOR: datadog-iot-agent
+        FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
       - IMAGE: opensuse/leap:15.4
-      - IMAGE: opensuse/leap:15.4
-        FLAVOR: datadog-dogstatsd
-      - IMAGE: opensuse/leap:15.4
-        FLAVOR: datadog-iot-agent
+        FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
       - IMAGE: debian:12.1
   artifacts:
     name: "artifacts"
@@ -156,17 +134,17 @@ test:
 test-yaml-redhat:
   extends: .test-yaml
   needs:
-    - "test: [centos:centos7]"
+    - "test: [centos:centos7, datadog-agent]"
 
 test-yaml-debian:
   extends: .test-yaml
   needs:
-    - "test: [ubuntu:14.04]"
+    - "test: [ubuntu:14.04, datadog-agent]"
 
 test-yaml-suse:
   extends: .test-yaml
   needs:
-    - "test: [opensuse/archive:42.3]"
+    - "test: [opensuse/archive:42.3, datadog-agent]"
 
 test-apm-injection:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64:$DATADOG_AGENT_BUILDIMAGES
@@ -205,27 +183,8 @@ test-observability-pipelines-worker:
   dependencies: ["generate-scripts"]
   parallel:
     matrix:
-      - IMAGE: amazonlinux:2
-      - IMAGE: amazonlinux:2023
-      - IMAGE: debian:10
-      - IMAGE: debian:11
-      - IMAGE: rockylinux:9.0
-      - IMAGE: ubuntu:20.04
-      - IMAGE: ubuntu:22.04
-      - IMAGE: amazonlinux:2
-        INSTALL_CLASSIC_AGENT: --opw-install-classic-agent install_script_agent7.sh
-      - IMAGE: amazonlinux:2023
-        INSTALL_CLASSIC_AGENT: --opw-install-classic-agent install_script_agent7.sh
-      - IMAGE: debian:10
-        INSTALL_CLASSIC_AGENT: --opw-install-classic-agent install_script_agent7.sh
-      - IMAGE: debian:11
-        INSTALL_CLASSIC_AGENT: --opw-install-classic-agent install_script_agent7.sh
-      - IMAGE: rockylinux:9.0
-        INSTALL_CLASSIC_AGENT: --opw-install-classic-agent install_script_agent7.sh
-      - IMAGE: ubuntu:20.04
-        INSTALL_CLASSIC_AGENT: --opw-install-classic-agent install_script_agent7.sh
-      - IMAGE: ubuntu:22.04
-        INSTALL_CLASSIC_AGENT: --opw-install-classic-agent install_script_agent7.sh
+      - IMAGE: [amazonlinux:2, amazonlinux:2023, debian:10, debian:11, rockylinux:9.0, ubuntu:20.04, ubuntu:22.04]
+        INSTALL_CLASSIC_AGENT: ['', --opw-install-classic-agent install_script_agent7.sh]
   script:
     - ./test/dockertest.sh --image "registry.ddbuild.io/images/mirror/${IMAGE}" --script install_script_op_worker1.sh --observability-pipelines-worker "true" --minor-version "${MINOR_VERSION}" --expected-minor-version "${EXPECTED_MINOR_VERSION}" ${INSTALL_CLASSIC_AGENT}
 
@@ -238,13 +197,7 @@ test-vector:
   dependencies: ["generate-scripts"]
   parallel:
     matrix:
-      - IMAGE: amazonlinux:2
-      - IMAGE: amazonlinux:2023
-      - IMAGE: debian:10
-      - IMAGE: debian:11
-      - IMAGE: rockylinux:9.0
-      - IMAGE: ubuntu:20.04
-      - IMAGE: ubuntu:22.04
+      - IMAGE: [amazonlinux:2, amazonlinux:2023, debian:10, debian:11, rockylinux:9.0, ubuntu:20.04, ubuntu:22.04]
   script:
     - ./test/dockertest.sh --image "registry.ddbuild.io/images/mirror/${IMAGE}" --script install_script_vector0.sh --vector "true"
 

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -138,7 +138,7 @@ security_agent_config_file=/etc/datadog-agent/security-agent.yaml
 system_probe_config_file=/etc/datadog-agent/system-probe.yaml
 config_files=( "$config_file" "$security_agent_config_file" "$system_probe_config_file" )
 mkdir -p "/tmp/vol/artifacts"
-if [[ -z "$DD_AGENT_FLAVOR" && -z "$DD_NO_AGENT_INSTALL" ]]; then
+if [[ ( -z "$DD_AGENT_FLAVOR" || "$DD_AGENT_FLAVOR" = "datadog-agent" ) && -z "$DD_NO_AGENT_INSTALL" ]]; then
   for file in "${config_files[@]}"; do
     cp "$file" "/tmp/vol/artifacts"
   done


### PR DESCRIPTION
By using a more compacted form it will be easier to add more dimensions to those matrices later on.

More specifically, in order to migrate to k8s we'd ideally need to have a single job per major version as we won't be able to start containers from the job, which will require a new matrix entry.