### PR TITLE
Revert "Prepare 1.24.0 release"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,8 @@
 Release Notes
 =============
 
-1.24.0
+Unreleased
 ================
-
-- Remove usage of the datadog-apm-library-all (#111)
-- Prevent errors when trying to install with no_agent in RHEL OS (#112)
-- Generate an install signature on success and include in telemetry events (#110)
-- invite users to add dd-agent to docker group (#105)
 
 1.23.0
 ================

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -9,7 +9,7 @@ set -e
 
 DEPRECATION_MESSAGE_PLACEHOLDER
 
-install_script_version=1.24.0
+install_script_version=1.23.0.post
 logfile="ddagent-install.log"
 support_email=support@datadoghq.com
 variant=install_scriptINSTALL_INFO_VERSION_PLACEHOLDER

--- a/install_script_op_worker1.sh
+++ b/install_script_op_worker1.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-install_script_version=1.24.0
+install_script_version=1.23.0.post
 logfile="dd-install.log"
 support_email=support@datadoghq.com
 variant=install_script_op_worker1


### PR DESCRIPTION
Reverts DataDog/agent-linux-install-script#115

Since we will do the release only after the freeze, let's revert this one for now