### PR TITLE
dockertest.sh: revert parameters removal

### DIFF
--- a/test/dockertest.sh
+++ b/test/dockertest.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+PLATFORM="linux/amd64"
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     -s|--script)
@@ -7,6 +9,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     -i|--image)
       IMAGE="$2"
+      ;;
+    -v|--minor-version)
+      MINOR_VERSION="$2"
+      ;;
+    -e|--expected-minor-version)
+      EXPECTED_MINOR_VERSION="$2"
+      ;;
+    -f|--flavor)
+      FLAVOR="$2"
+      ;;
+    -p|--platform)
+      PLATFORM="$2"
       ;;
     --injection)
       DD_APM_INSTRUMENTATION_ENABLED="$2"
@@ -57,7 +71,7 @@ else
     ENTRYPOINT_PATH="/tmp/vol/test/localtest.sh"
 fi
 
-docker run --rm -v "$(pwd):/tmp/vol" \
+docker run --rm --platform "$PLATFORM" -v "$(pwd):/tmp/vol" \
   -e DD_SYSTEM_PROBE_ENSURE_CONFIG="${DD_SYSTEM_PROBE_ENSURE_CONFIG}" \
   -e DD_COMPLIANCE_CONFIG_ENABLED="${DD_COMPLIANCE_CONFIG_ENABLED}" \
   -e DD_RUNTIME_SECURITY_CONFIG_ENABLED="${DD_RUNTIME_SECURITY_CONFIG_ENABLED}" \


### PR DESCRIPTION
While this made sense in the context of the CI, it impeeds the developers ability to run tests locally on a docker container