### PR TITLE
CI: only run APM tests on push

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,6 +149,8 @@ test-apm-injection:
   tags: ["runner:docker"]
   stage: test
   dependencies: ["generate-scripts"]
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
   parallel:
     # Docker testing is not possible because of docker-in-docker
     # Host injection requires the agent to be present


### PR DESCRIPTION
Replicate what's done for OPW tests.
The intent is to stop running APM tests when triggering an install-script pipeline from the datadog-agent pipeline. These triggered pipeline use a specific testing repository which doesn't contain any APM binary, which causes the tests to fail