### PR TITLE
Ensure correct behaviour with security_agent and system_probe configuration files

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1193,22 +1193,37 @@ function update_env(){
     $sudo_cmd sh -c "sed -i 's/^# env:.*/env: $dd_env/' $config_file"
   fi
 }
-function update_runtime_security(){
+function update_security_and_or_compliance(){
   local sudo_cmd="$1"
   local local_config_file="$2"
-  if ensure_config_file_exists "$sudo_cmd" "$local_config_file" "root"; then
-    printf "\033[34m\n* Enabling runtime security in $(basename "$local_config_file") configuration\n\033[0m\n"
+  local enable_security="$3"
+  local enable_compliance="$4"
+  if [ "$enable_security" == "true" ]; then
+    printf "\033[34m\n* Enabling runtime security in $local_config_file configuration\n\033[0m\n"
     $sudo_cmd sh -c "sed -i 's/^#\s*runtime_security_config:$/runtime_security_config:/' $local_config_file"
     $sudo_cmd sh -c "sed -i '/^runtime_security_config:/,// s/\(\s\+\)#\s*enabled:\s*false/\1enabled: true/' $local_config_file"
   fi
-}
-function update_compliance_configuration(){
-  local sudo_cmd="$1"
-  local local_config_file="$2"
-  if ensure_config_file_exists "$sudo_cmd" "$local_config_file" "root"; then
-    printf "\033[34m\n* Enabling compliance monitoring in $(basename "$local_config_file") configuration\n\033[0m\n"
+  if [ "$enable_compliance" == "true" ]; then
+    printf "\033[34m\n* Enabling compliance monitoring in $local_config_file configuration\n\033[0m\n"
     $sudo_cmd sh -c "sed -i 's/^#\s*compliance_config:$/compliance_config:/' $local_config_file"
     $sudo_cmd sh -c "sed -i '/^compliance_config:/,// s/\(\s\+\)#\s*enabled:\s*false/\1enabled: true/' $local_config_file"
+  fi
+}
+function manage_security_and_system_probe_config(){
+  local sudo_cmd="$1"
+  local security_config_file="$2"
+  local probe_config_file="$3"
+  local enable_security="$4"
+  local enable_compliance="$5"
+  if [ "$enable_security" == "true" ] || [ "$enable_compliance" == "true" ]; then
+    if ensure_config_file_exists "$sudo_cmd" "$security_config_file" "root"; then
+      update_security_and_or_compliance "$sudo_cmd" "$security_config_file" "$enable_security" "$enable_compliance"
+    fi
+    if [ "$enable_security" == "true" ]; then
+      if ensure_config_file_exists "$sudo_cmd" "$probe_config_file" "root"; then
+        update_security_and_or_compliance "$sudo_cmd" "$probe_config_file" "$enable_security" "false"
+      fi
+    fi
   fi
 }
 # "Main" configuration update
@@ -1227,13 +1242,7 @@ elif [ ! "$no_agent" ]; then
     update_hosttags "$sudo_cmd" "$host_tags" "$config_file"
     update_env "$sudo_cmd" "$dd_env" "$config_file"
   fi
-  if [ "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" == "true" ]; then
-    update_runtime_security "$sudo_cmd" "$security_agent_config_file"
-    update_runtime_security "$sudo_cmd" "$system_probe_config_file"
-  fi
-  if [ "$DD_COMPLIANCE_CONFIG_ENABLED" == "true" ]; then
-    update_compliance_configuration "$sudo_cmd" "$security_agent_config_file"
-  fi
+  manage_security_and_system_probe_config "$sudo_cmd" "$security_agent_config_file" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
 fi
 
 if [ ! "$no_agent" ]; then

--- a/test/e2e/install_maximal_and_replay_test.go
+++ b/test/e2e/install_maximal_and_replay_test.go
@@ -26,8 +26,9 @@ var (
 		"* Adding your HOSTNAME to the Datadog Agent configuration: /etc/datadog-agent/datadog.yaml",
 		"* Adding your HOST TAGS to the Datadog Agent configuration: /etc/datadog-agent/datadog.yaml",
 		"* Adding your DD_ENV to the Datadog Agent configuration: /etc/datadog-agent/datadog.yaml",
-		"* Enabling compliance monitoring in security-agent.yaml configuration",
-		"* Enabling runtime security in system-probe.yaml configuration",
+		"* Enabling runtime security in /etc/datadog-agent/security-agent.yaml configuration",
+		"* Enabling compliance monitoring in /etc/datadog-agent/security-agent.yaml configuration",
+		"* Enabling runtime security in /etc/datadog-agent/system-probe.yaml configuration",
 	}
 )
 

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -13,19 +13,16 @@ testEnsureExists() {
   ensure_config_file_exists "sudo" "/etc/hosts" "root"
   assertEquals 1 $?
 }
-
 testEnsureExistsWrongSudo() {
   sudo rm /etc/datadog-agent/datadog.yaml
   ensure_config_file_exists "sumo" $config_file "dd-agent"
   assertEquals 125 $?
 }
-
 testEnsureExistsFailsWrongUser() {
   sudo rm /etc/datadog-agent/datadog.yaml
   ensure_config_file_exists "sudo" $config_file "datad0g-agent"
   assertEquals 1 $?
 }
-
 testEnsureNotExists() {
   sudo rm /etc/datadog-agent/datadog.yaml
   ensure_config_file_exists "sudo" $config_file "dd-agent"
@@ -149,43 +146,106 @@ testNoEnv(){
   sudo grep -wq "^# env: <environment name>$" $config_file
   assertEquals 0 $?
 }
-### update_runtime_security
+
+### update_security_and_or_compliance
 testRuntimeSecurityUpdated() {
-  sudo rm $security_agent_config_file
-  update_runtime_security "sudo" $security_agent_config_file
+  sudo cp ${security_agent_config_file}.example $security_agent_config_file
+  update_security_and_or_compliance "sudo" $security_agent_config_file true false
   yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
   assertEquals 0 $?
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
 }
 testRuntimeSecurityUpdatedSystemPrope() {
-  sudo rm $system_probe_config_file
-  update_runtime_security "sudo" $system_probe_config_file
+  sudo cp ${system_probe_config_file}.example $system_probe_config_file
+  update_security_and_or_compliance "sudo" $system_probe_config_file true false
   yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
   assertEquals 0 $?
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
 }
-testRuntimeSecurityDisabled() {
-  sudo cp ${security_agent_config_file}.example $security_agent_config_file
-  update_runtime_security "sudo" $security_agent_config_file
-  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
-  assertEquals 1 $?
-}
-
-### update_compliance_configuration
 testComplianceConfigurationUpdated() {
-  sudo rm $security_agent_config_file
-  update_compliance_configuration "sudo" $security_agent_config_file
+  sudo cp ${security_agent_config_file}.example $security_agent_config_file
+  update_security_and_or_compliance "sudo" $security_agent_config_file false true
   yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
   assertEquals 0 $?
   sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
 }
-testComplianceConfigurationDisabled() {
+testSecurityAndComplianceEnabled() {
   sudo cp ${security_agent_config_file}.example $security_agent_config_file
-  update_compliance_configuration "sudo" $security_agent_config_file
+  sudo cp ${system_probe_config_file}.example $system_probe_config_file
+  update_security_and_or_compliance "sudo" $security_agent_config_file true true
+  yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
+  assertEquals 0 $?
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
   sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+}
+testSecurityAndComplianceDisabled() {
+  sudo cp ${security_agent_config_file}.example $security_agent_config_file
+  update_security_and_or_compliance "sudo" $security_agent_config_file false false
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 1 $?
+  sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 1 $?
+}
+
+### Manage security and probe config files
+testNoCreation() {
+  sudo rm $security_agent_config_file $system_probe_config_file 2> /dev/null
+  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file false false
+  sudo test -e $security_agent_config_file
+  assertEquals 1 $?
+  sudo test -e $system_probe_config_file
+  assertEquals 1 $?
+}
+testPreventOnBoth() {
+  sudo cp ${security_agent_config_file}.example $security_agent_config_file
+  sudo cp ${system_probe_config_file}.example $system_probe_config_file
+  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file true true
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 1 $?
+  sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 1 $?
+}
+testComplianceOnSecurity(){
+  sudo rm $security_agent_config_file $system_probe_config_file 2> /dev/null
+  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file false true
+  yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
+  assertEquals 0 $?
+  sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+  sudo test -e $system_probe_config_file
+  assertEquals 1 $?
+}
+testSecOnBoth(){
+  sudo rm $security_agent_config_file $system_probe_config_file 2> /dev/null
+  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file true false
+  yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
+  assertEquals 0 $?
+  yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
+  assertEquals 0 $?
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+}
+testFullConfig(){
+  sudo rm $security_agent_config_file $system_probe_config_file 2> /dev/null
+  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file true true
+  yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
+  assertEquals 0 $?
+  yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
+  assertEquals 0 $?
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+  sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+  sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 1 $?
 }
 


### PR DESCRIPTION
Restore the previous behaviour, pseudo-code:
```
if DD_RUNTIME_SECURITY_CONFIG_ENABLED
 create both files if they don't already exist
 update security config in both files
if DD_COMPLIANCE_CONFIG_ENABLED
 create security file if it doesn't already exist
 update compliance config on it
```
This was changed to take benefit of `ensure_config_file_exist` and have testable methods