### PR TITLE
feat(documentation): Add information about the configuration options of install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,65 @@ This repository contains the code to generate various versions of the Datadog Ag
 * https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh to install Agent 6
 * https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh to install Agent 7
 
-Usage instructions for the install script are in the [Datadog App](https://app.datadoghq.com/account/settings#agent/overview).
+
+## Agent install script usage
+Basic usage instructions for the agent install script are in the [Datadog App](https://app.datadoghq.com/account/settings#agent/overview).
+
+### Agent configuration options
+Install script allows installation of different flavours of the Agent binaries and allows automatic setting of some configuration options. We list them below with their diffent possible values. 
+
+> [!IMPORTANT]
+> All variables are optional except `DD_API_KEY`, which is required unless `DD_UPGRADE` (upgrade from datadog-agent 5) is set.
+
+> [!WARNING]
+> Install script input options are only considered at initial installation, and they don't overwrite pre-existing configuration files
+
+| Variable | Description|
+|-|-|
+|`DD_AGENT_FLAVOR`|The agent binary to install. Possible values are `datadog-agent`(default), `datadog-iot-agent`, `datadog-dogstatsd`, `datadog-fips-proxy`, `datadog-heroku-agent`.|
+|`DD_API_KEY`|The application key to access Datadog's programatic API.|
+|`DD_SITE`|The site of the Datadog intake to send Agent data to (e.g. `datadoghq.com`)|
+|`DD_URL`|The host of the Datadog intake server to send metrics to (e.g. `https://app.datadoghq.com`). Only set this option if you need the Agent to send metrics to a custom URL: it overrides the site setting defined in "site". It does not affect APM, Logs or Live Process intake which have their own "*_dd_url" settings.|
+|`DD_HOSTNAME`|Force the hostname name.|
+|`DD_HOST_TAGS`|List of host tags, defined as a comma-separated list of `key:value` strings (e.g. `team:infra,env:prod`) Attached in-app to every metric, event, log, trace, and service check emitted by this Agent.|
+|`DD_UPGRADE`|Set to any value to trigger a version upgrade from datadog-agent 5. It will import configuration files from `/etc/dd-agent/datadog.conf`. Not compatible with `DD_AGENT_FLAVOR=datadog-dogstatsd`.|
+|`DD_FIPS_MODE`|Set to any value to enable the use of the FIPS proxy to send data to the DataDog backend. Enabling this will force all outgoing traffic from the Agent to the local proxy. It's important to note that enabling this will not make the Datadog Agent FIPS compliant, but will force all outgoing traffic to a local FIPS compliant proxy. By-pass `DD_SITE` and `DD_URL` when enabled|
+|`DD_ENV`|The environment name where the agent is running. Attached in-app to every metric, event, log, trace, and service check emitted by this Agent.|
+|`DD_APM_INSTRUMENTATION_ENABLED`|Automatically instrument all your application processes alongside agent installation. Possible values are `host`, `docker` or `all` (`all` is both `host` and `docker`). `docker` value will check if docker is installed and will set `DD_NO_INSTALL` to `true`. If `DD_APM_INSTRUMENTATION_LANGUAGES` is not set, it will enable all libraries: `java`, `js`, `python`, `dotnet` and `ruby`. `host` injection is not compatible with the `DD_NO_AGENT_INSTALL` option. Only supported on Agent v7. Not supported on SUSE.|
+|`DD_APM_INSTRUMENTATION_LANGUAGES`|Specify the APM library to be installed. Possible values are `all`, `java`, `js`, `python`, `dotnet` and `ruby`. Does not run the APM injection script, which are triggered by `DD_APM_INSTRUMENTATION_ENABLED`.|
+|`DD_APM_INSTRUMENTATION_NO_CONFIG_CHANGE`|Set to any value to pass the `--no-config-change` option to the APM host injection script.|
+|`DD_SYSTEM_PROBE_ENSURE_CONFIG`|Create the system probe configuration file from templace, if it does not already exist.|
+|`DD_RUNTIME_SECURITY_CONFIG_ENABLED`|If set to `true`, ensure creation of security agent and system probe configuration file (if they don't already exist), and enable Cloud Workload Security (CWS).|
+|`DD_COMPLIANCE_CONFIG_ENABLED`|If set to `true`, ensure creation of security agent configuration file (if it doesn't already exist), and enable Cloud Security Posture Management (CSPM).|
+|`DD_INSTALL_ONLY`|Set to any value to prevent starting the agent after installation.|
+|`DD_NO_AGENT_INSTALL`|Do not install the agent. It will install package signature keys and create configuration files if they don't already exist.Automatically set to `true` when `DD_APM_INSTRUMENTATION_ENABLED=docker`.|
+
+
+## Install script configuration options
+Install script also comes with its own configuration options for testing purpose.
+
+>[!WARNING]
+> These options are for datadog internal use only.
+
+| Variable | Description|
+|-|-|
+|`DD_INSTRUMENTATION_TELEMETRY_ENABLED`|`true` if not set. When `false`, won't report telemetry to Datadog in case of script issue.|
+|`DD_REPO_URL`|Domain name of the package S3 bucket to target. Default to `datadoghq.com`.|
+|`REPO_URL`|Deprecated, use `DD_REPO_URL` instead.|
+|`DD_RPM_REPO_GPGCHECK`|Turn on or off the `repo_gpgcheck` on RPM distributions. Possible values are `0` or `1`. Unless explicitely set, we turn off when `DD_REPO_URL` is set.|
+|`DD_AGENT_MAJOR_VERSION`|The Agent major version. Must be `6` or `7`|
+|`DD_AGENT_MINOR_VERSION`|Full or partial version numbers from the minor digit. Example: `20` will default to the highest patch version. `20.0~rc.5` will explicitely target this version. An invalid minor version will terminate the script.|
+|`DD_AGENT_DIST_CHANNEL`|The package distribution channel. Possible values are `stable` or `beta` on production repositories, and `stable`, `beta` or `nightly` on custom repositories. Other channels can be target by `TESTING_APT_URL` or `TESTING_YUM_URL`|
+|`TESTING_KEYS_URL`|The URL to retrieve the package signature keys. Default to `keys.datadoghq.com`.|
+|`TESTING_APT_URL`|Replace the whole APT bucket url. Useful to test with trial buckets.|
+|`TESTING_YUM_URL`|Replace the whole YUM bucket url. Useful to test with trial buckets.|
+|`TESTING_REPORT_URL`|A custom URL to receive the report and telemetry in case of script failure.|
+|`TESTING_APT_REPO_VERSION`|A custom name for the APT package. To be used with `TESTING_APT_URL` to target trial buckets.|
+|`TESTING_YUM_VERSION_PATH`|A custom name for the YUM package. To be used with `TESTING_YUM_URL` to target trial buckets.|
+
+
+## Others scripts
+This repository also contains install script for Observability Pipelines Worker and Vector. More information on documentation pages for [OPW](https://docs.datadoghq.com/observability_pipelines/setup/?tab=docker) and [Vector](https://vector.dev/docs/setup/installation/)
 
 ## Working with this repository
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ The install script allows installation of different flavors of the Agent binarie
 > All variables are optional except `DD_API_KEY`, which is required unless `DD_UPGRADE` (upgrade from datadog-agent 5) is set.
 
 > [!WARNING]
-> The install script input options are only considered at initial installation and they don't overwrite pre-existing configuration files
+> The install script input options are only considered at initial installation and they don't overwrite pre-existing configuration files.
 
 | Variable | Description|
 |-|-|
 |`DD_AGENT_FLAVOR`|The Agent binary to install. Possible values are `datadog-agent`(default), `datadog-iot-agent`, `datadog-dogstatsd`, `datadog-fips-proxy`, `datadog-heroku-agent`.|
 |`DD_API_KEY`|The application key to access Datadog's programatic API.|
-|`DD_SITE`|The site of the Datadog intake to send Agent data to. For example, `datadoghq.com`. For more information on Datadog sites, see [Getting Started with Datadog Sites](https://docs.datadoghq.com/getting_started/site/)|
+|`DD_SITE`|The site of the Datadog intake to send Agent data to. For example, `datadoghq.com`. For more information on Datadog sites, see [Getting Started with Datadog Sites](https://docs.datadoghq.com/getting_started/site/).|
 |`DD_URL`|The host of the Datadog intake server to send metrics to. For example, `https://app.datadoghq.com`. Only set this option if you need the Agent to send metrics to a custom URL: it overrides the site setting defined in `site`. It does not affect APM, Logs or Live Process intake which have their own `*_dd_url` settings.|
-|`DD_HOSTNAME`|Force the hostname name.|
+|`DD_HOSTNAME`|Force the hostname value.|
 |`DD_HOST_TAGS`|List of host tags, defined as a comma-separated list of `key:value` strings. For example, `team:infra,env:prod`. Host tags are attached in-app to every metric, event, log, trace, and service check emitted by this Agent.|
 |`DD_UPGRADE`|Set to any value to trigger a version upgrade from datadog-agent 5. Imports configuration files from `/etc/dd-agent/datadog.conf`. Not compatible with `DD_AGENT_FLAVOR=datadog-dogstatsd`.|
 |`DD_FIPS_MODE`|Set to any value to enable the use of the FIPS proxy to send data to the DataDog backend. Enabling this option forces all outgoing traffic from the Agent to the local proxy. It's important to note that enabling this will not make the Datadog Agent FIPS compliant, but will force all outgoing traffic to a local FIPS compliant proxy. By-pass `DD_SITE` and `DD_URL` when enabled. For more information on FIPS compliance, see [FIPS Compliance](https://docs.datadoghq.com/agent/configuration/agent-fips-proxy/).|
@@ -43,7 +43,7 @@ The install script allows installation of different flavors of the Agent binarie
 The install script also comes with its own configuration options for testing purpose.
 
 >[!WARNING]
-> These options are for Datadog internal use only.
+> These options are intended for Datadog internal use only.
 
 | Variable | Description|
 |-|-|
@@ -51,9 +51,9 @@ The install script also comes with its own configuration options for testing pur
 |`DD_REPO_URL`|Domain name of the package S3 bucket to target. Default to `datadoghq.com`.|
 |`REPO_URL`|Deprecated, use `DD_REPO_URL` instead.|
 |`DD_RPM_REPO_GPGCHECK`|Turn on or off the `repo_gpgcheck` on RPM distributions. Possible values are `0` or `1`. Unless explicitely set, we turn off when `DD_REPO_URL` is set.|
-|`DD_AGENT_MAJOR_VERSION`|The Agent major version. Must be `6` or `7`|
+|`DD_AGENT_MAJOR_VERSION`|The Agent major version. Must be `6` or `7`.|
 |`DD_AGENT_MINOR_VERSION`|Full or partial version numbers from the minor digit. Example: `20` defaults to the highest patch version. `20.0~rc.5` explicitly targets this version. An invalid minor version terminates the script.|
-|`DD_AGENT_DIST_CHANNEL`|The package distribution channel. Possible values are `stable` or `beta` on production repositories, and `stable`, `beta` or `nightly` on custom repositories. Other channels can be targeted with `TESTING_APT_URL` or `TESTING_YUM_URL`|
+|`DD_AGENT_DIST_CHANNEL`|The package distribution channel. Possible values are `stable` or `beta` on production repositories, and `stable`, `beta` or `nightly` on custom repositories. Other channels can be targeted with `TESTING_APT_URL` or `TESTING_YUM_URL`.|
 |`TESTING_KEYS_URL`|The URL to retrieve the package signature keys. Default to `keys.datadoghq.com`.|
 |`TESTING_APT_URL`|Replace the whole APT bucket URL. Useful to test with trial buckets.|
 |`TESTING_YUM_URL`|Replace the whole YUM bucket URL. Useful to test with trial buckets.|
@@ -63,7 +63,7 @@ The install script also comes with its own configuration options for testing pur
 
 
 ## Others scripts
-This repository also contains install scripts for Observability Pipelines Worker and Vector. For more information, see the documentation for [OPW](https://docs.datadoghq.com/observability_pipelines/setup/?tab=docker) and [Vector](https://vector.dev/docs/setup/installation/)
+This repository also contains install scripts for Observability Pipelines Worker and Vector. For more information, see the documentation for [OPW](https://docs.datadoghq.com/observability_pipelines/setup/?tab=docker) and [Vector](https://vector.dev/docs/setup/installation/).
 
 ## Working with this repository
 

--- a/README.md
+++ b/README.md
@@ -7,63 +7,63 @@ This repository contains the code to generate various versions of the Datadog Ag
 
 
 ## Agent install script usage
-Basic usage instructions for the agent install script are in the [Datadog App](https://app.datadoghq.com/account/settings#agent/overview).
+Basic usage instructions for the Agent install script are in the [Datadog App](https://app.datadoghq.com/account/settings#agent/overview).
 
 ### Agent configuration options
-Install script allows installation of different flavours of the Agent binaries and allows automatic setting of some configuration options. We list them below with their diffent possible values. 
+The install script allows installation of different flavors of the Agent binaries and allows you to set some configuration options automatically. We list them below with their different possible values. 
 
 > [!IMPORTANT]
 > All variables are optional except `DD_API_KEY`, which is required unless `DD_UPGRADE` (upgrade from datadog-agent 5) is set.
 
 > [!WARNING]
-> Install script input options are only considered at initial installation, and they don't overwrite pre-existing configuration files
+> The install script input options are only considered at initial installation and they don't overwrite pre-existing configuration files
 
 | Variable | Description|
 |-|-|
-|`DD_AGENT_FLAVOR`|The agent binary to install. Possible values are `datadog-agent`(default), `datadog-iot-agent`, `datadog-dogstatsd`, `datadog-fips-proxy`, `datadog-heroku-agent`.|
+|`DD_AGENT_FLAVOR`|The Agent binary to install. Possible values are `datadog-agent`(default), `datadog-iot-agent`, `datadog-dogstatsd`, `datadog-fips-proxy`, `datadog-heroku-agent`.|
 |`DD_API_KEY`|The application key to access Datadog's programatic API.|
-|`DD_SITE`|The site of the Datadog intake to send Agent data to (e.g. `datadoghq.com`)|
-|`DD_URL`|The host of the Datadog intake server to send metrics to (e.g. `https://app.datadoghq.com`). Only set this option if you need the Agent to send metrics to a custom URL: it overrides the site setting defined in "site". It does not affect APM, Logs or Live Process intake which have their own "*_dd_url" settings.|
+|`DD_SITE`|The site of the Datadog intake to send Agent data to. For example, `datadoghq.com`. For more information on Datadog sites, see [Getting Started with Datadog Sites](https://docs.datadoghq.com/getting_started/site/)|
+|`DD_URL`|The host of the Datadog intake server to send metrics to. For example, `https://app.datadoghq.com`. Only set this option if you need the Agent to send metrics to a custom URL: it overrides the site setting defined in `site`. It does not affect APM, Logs or Live Process intake which have their own `*_dd_url` settings.|
 |`DD_HOSTNAME`|Force the hostname name.|
-|`DD_HOST_TAGS`|List of host tags, defined as a comma-separated list of `key:value` strings (e.g. `team:infra,env:prod`) Attached in-app to every metric, event, log, trace, and service check emitted by this Agent.|
-|`DD_UPGRADE`|Set to any value to trigger a version upgrade from datadog-agent 5. It will import configuration files from `/etc/dd-agent/datadog.conf`. Not compatible with `DD_AGENT_FLAVOR=datadog-dogstatsd`.|
-|`DD_FIPS_MODE`|Set to any value to enable the use of the FIPS proxy to send data to the DataDog backend. Enabling this will force all outgoing traffic from the Agent to the local proxy. It's important to note that enabling this will not make the Datadog Agent FIPS compliant, but will force all outgoing traffic to a local FIPS compliant proxy. By-pass `DD_SITE` and `DD_URL` when enabled|
-|`DD_ENV`|The environment name where the agent is running. Attached in-app to every metric, event, log, trace, and service check emitted by this Agent.|
-|`DD_APM_INSTRUMENTATION_ENABLED`|Automatically instrument all your application processes alongside agent installation. Possible values are `host`, `docker` or `all` (`all` is both `host` and `docker`). `docker` value will check if docker is installed and will set `DD_NO_INSTALL` to `true`. If `DD_APM_INSTRUMENTATION_LANGUAGES` is not set, it will enable all libraries: `java`, `js`, `python`, `dotnet` and `ruby`. `host` injection is not compatible with the `DD_NO_AGENT_INSTALL` option. Only supported on Agent v7. Not supported on SUSE.|
-|`DD_APM_INSTRUMENTATION_LANGUAGES`|Specify the APM library to be installed. Possible values are `all`, `java`, `js`, `python`, `dotnet` and `ruby`. Does not run the APM injection script, which are triggered by `DD_APM_INSTRUMENTATION_ENABLED`.|
+|`DD_HOST_TAGS`|List of host tags, defined as a comma-separated list of `key:value` strings. For example, `team:infra,env:prod`. Host tags are attached in-app to every metric, event, log, trace, and service check emitted by this Agent.|
+|`DD_UPGRADE`|Set to any value to trigger a version upgrade from datadog-agent 5. Imports configuration files from `/etc/dd-agent/datadog.conf`. Not compatible with `DD_AGENT_FLAVOR=datadog-dogstatsd`.|
+|`DD_FIPS_MODE`|Set to any value to enable the use of the FIPS proxy to send data to the DataDog backend. Enabling this option forces all outgoing traffic from the Agent to the local proxy. It's important to note that enabling this will not make the Datadog Agent FIPS compliant, but will force all outgoing traffic to a local FIPS compliant proxy. By-pass `DD_SITE` and `DD_URL` when enabled. For more information on FIPS compliance, see [FIPS Compliance](https://docs.datadoghq.com/agent/configuration/agent-fips-proxy/).|
+|`DD_ENV`|The environment name where the Agent is running. The environment name is attached in-app to every metric, event, log, trace, and service check emitted by this Agent.|
+|`DD_APM_INSTRUMENTATION_ENABLED`|Automatically instrument all your application processes alongside Agent installation. Possible values are `host`, `docker` or `all` (`all` is both `host` and `docker`). The `docker` value checks if Docker is installed and sets `DD_NO_INSTALL` to `true`. If `DD_APM_INSTRUMENTATION_LANGUAGES` is not set, it enables all libraries: `java`, `js`, `python`, `dotnet` and `ruby`. `host` injection is not compatible with the `DD_NO_AGENT_INSTALL` option. Only supported on Agent v7. Not supported on SUSE.|
+|`DD_APM_INSTRUMENTATION_LANGUAGES`|Specify the APM library to be installed. Possible values are `all`, `java`, `js`, `python`, `dotnet` and `ruby`. Does not run the APM injection script, which is triggered by `DD_APM_INSTRUMENTATION_ENABLED`.|
 |`DD_APM_INSTRUMENTATION_NO_CONFIG_CHANGE`|Set to any value to pass the `--no-config-change` option to the APM host injection script.|
-|`DD_SYSTEM_PROBE_ENSURE_CONFIG`|Create the system probe configuration file from templace, if it does not already exist.|
-|`DD_RUNTIME_SECURITY_CONFIG_ENABLED`|If set to `true`, ensure creation of security agent and system probe configuration file (if they don't already exist), and enable Cloud Workload Security (CWS).|
-|`DD_COMPLIANCE_CONFIG_ENABLED`|If set to `true`, ensure creation of security agent configuration file (if it doesn't already exist), and enable Cloud Security Posture Management (CSPM).|
-|`DD_INSTALL_ONLY`|Set to any value to prevent starting the agent after installation.|
-|`DD_NO_AGENT_INSTALL`|Do not install the agent. It will install package signature keys and create configuration files if they don't already exist.Automatically set to `true` when `DD_APM_INSTRUMENTATION_ENABLED=docker`.|
+|`DD_SYSTEM_PROBE_ENSURE_CONFIG`|Create the system probe configuration file from a template if it does not already exist.|
+|`DD_RUNTIME_SECURITY_CONFIG_ENABLED`|If set to `true`, ensure creation of security Agent and system probe configuration file (if they don't already exist), and enable Cloud Workload Security (CWS).|
+|`DD_COMPLIANCE_CONFIG_ENABLED`|If set to `true`, ensures the creation of a security Agent configuration file if one doesn't already exist, and enables Cloud Security Posture Management (CSPM).|
+|`DD_INSTALL_ONLY`|Set to any value to prevent starting the Agent after installation.|
+|`DD_NO_AGENT_INSTALL`|Do not install the Agent. Instead, installs package signature keys and creates configuration files if they don't already exist. Automatically set to `true` when `DD_APM_INSTRUMENTATION_ENABLED=docker`.|
 
 
 ## Install script configuration options
-Install script also comes with its own configuration options for testing purpose.
+The install script also comes with its own configuration options for testing purpose.
 
 >[!WARNING]
-> These options are for datadog internal use only.
+> These options are for Datadog internal use only.
 
 | Variable | Description|
 |-|-|
-|`DD_INSTRUMENTATION_TELEMETRY_ENABLED`|`true` if not set. When `false`, won't report telemetry to Datadog in case of script issue.|
+|`DD_INSTRUMENTATION_TELEMETRY_ENABLED`|`true` if not set. When `false`, doesn't report telemetry to Datadog in case of a script issue.|
 |`DD_REPO_URL`|Domain name of the package S3 bucket to target. Default to `datadoghq.com`.|
 |`REPO_URL`|Deprecated, use `DD_REPO_URL` instead.|
 |`DD_RPM_REPO_GPGCHECK`|Turn on or off the `repo_gpgcheck` on RPM distributions. Possible values are `0` or `1`. Unless explicitely set, we turn off when `DD_REPO_URL` is set.|
 |`DD_AGENT_MAJOR_VERSION`|The Agent major version. Must be `6` or `7`|
-|`DD_AGENT_MINOR_VERSION`|Full or partial version numbers from the minor digit. Example: `20` will default to the highest patch version. `20.0~rc.5` will explicitely target this version. An invalid minor version will terminate the script.|
-|`DD_AGENT_DIST_CHANNEL`|The package distribution channel. Possible values are `stable` or `beta` on production repositories, and `stable`, `beta` or `nightly` on custom repositories. Other channels can be target by `TESTING_APT_URL` or `TESTING_YUM_URL`|
+|`DD_AGENT_MINOR_VERSION`|Full or partial version numbers from the minor digit. Example: `20` defaults to the highest patch version. `20.0~rc.5` explicitly targets this version. An invalid minor version terminates the script.|
+|`DD_AGENT_DIST_CHANNEL`|The package distribution channel. Possible values are `stable` or `beta` on production repositories, and `stable`, `beta` or `nightly` on custom repositories. Other channels can be targeted with `TESTING_APT_URL` or `TESTING_YUM_URL`|
 |`TESTING_KEYS_URL`|The URL to retrieve the package signature keys. Default to `keys.datadoghq.com`.|
-|`TESTING_APT_URL`|Replace the whole APT bucket url. Useful to test with trial buckets.|
-|`TESTING_YUM_URL`|Replace the whole YUM bucket url. Useful to test with trial buckets.|
-|`TESTING_REPORT_URL`|A custom URL to receive the report and telemetry in case of script failure.|
+|`TESTING_APT_URL`|Replace the whole APT bucket URL. Useful to test with trial buckets.|
+|`TESTING_YUM_URL`|Replace the whole YUM bucket URL. Useful to test with trial buckets.|
+|`TESTING_REPORT_URL`|A custom URL to receive the report and telemetry in case of a script failure.|
 |`TESTING_APT_REPO_VERSION`|A custom name for the APT package. To be used with `TESTING_APT_URL` to target trial buckets.|
 |`TESTING_YUM_VERSION_PATH`|A custom name for the YUM package. To be used with `TESTING_YUM_URL` to target trial buckets.|
 
 
 ## Others scripts
-This repository also contains install script for Observability Pipelines Worker and Vector. More information on documentation pages for [OPW](https://docs.datadoghq.com/observability_pipelines/setup/?tab=docker) and [Vector](https://vector.dev/docs/setup/installation/)
+This repository also contains install scripts for Observability Pipelines Worker and Vector. For more information, see the documentation for [OPW](https://docs.datadoghq.com/observability_pipelines/setup/?tab=docker) and [Vector](https://vector.dev/docs/setup/installation/)
 
 ## Working with this repository
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -319,7 +319,7 @@ echo -e "\033[34m\n* Datadog INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER install s
 
 ##
 # AGENT CONFIGURATION OPTIONS
-# They are only considered if the configuration file do not already exist (call to `ensure_config_file_exist`)
+# They are only considered if the configuration file does not already exist (call to `ensure_config_file_exist`)
 ##
 hostname=
 if [ -n "$DD_HOSTNAME" ]; then
@@ -388,7 +388,7 @@ fi
 
 ##
 # INSTALL SCRIPT CONFIGURATION OPTIONS
-# Technical options to test with non production values for signature keys, packages or reporting telemetry.
+# Technical options to test with non-production values for signature keys, packages or reporting telemetry.
 ##
 if [ -n "$TESTING_KEYS_URL" ]; then
   keys_url=$TESTING_KEYS_URL

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -53,7 +53,7 @@ trap 'rm -f $npipe' EXIT
 
 ##
 # REPORTING AND COMMON METHODS
-#
+##
 function fallback_msg(){
   printf "
 If you are still having problems, please send an email to $support_email

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -51,6 +51,9 @@ exec 1>&-
 exec 1>$npipe 2>&1
 trap 'rm -f $npipe' EXIT
 
+##
+# REPORTING AND COMMON METHODS
+#
 function fallback_msg(){
   printf "
 If you are still having problems, please send an email to $support_email
@@ -264,6 +267,35 @@ function remove_rpm_gpg_keys() {
     done
 }
 
+# Emulate hashmap with simple switch case
+function getMapData() {
+
+    if [ "$1" = "flavor_to_readable" ]; then
+        case "$2" in
+            "datadog-agent")
+                DATA="Datadog Agent"
+                ;;
+             "datadog-iot-agent")
+                DATA="Datadog IoT Agent"
+                ;;
+             "datadog-dogstatsd")
+                DATA="Datadog Dogstatsd"
+                ;;
+             "datadog-fips-proxy")
+                DATA="Datadog FIPS Proxy"
+                ;;
+             "datadog-heroku-agent")
+                DATA="Datadog Heroku Agent"
+                ;;
+              *)
+                DATA="Unknown"
+                ;;
+         esac
+    fi
+    printf '%s' "$DATA"
+}
+
+# Create a configuration file with proper ownership and permission if it doesn't already exist
 function ensure_config_file_exists() {
     local sudo_cmd="$1"
     local config_file="$2"
@@ -285,6 +317,10 @@ function ensure_config_file_exists() {
 
 echo -e "\033[34m\n* Datadog INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER install script v${install_script_version}\n\033[0m"
 
+##
+# AGENT CONFIGURATION OPTIONS
+# They are only considered if the configuration file do not already exist (call to `ensure_config_file_exist`)
+##
 hostname=
 if [ -n "$DD_HOSTNAME" ]; then
     hostname=$DD_HOSTNAME
@@ -310,8 +346,7 @@ if [ -n "$DD_NO_AGENT_INSTALL" ]; then
     no_agent=true
 fi
 
-host_tags=
-# comma-separated list of tags
+host_tags=  # A comma-separated list of tags, e.g. foo:bar,env:prod
 if [ -n "$DD_HOST_TAGS" ]; then
     host_tags=$DD_HOST_TAGS
 fi
@@ -325,6 +360,36 @@ else
     repository_url="datadoghq.com"
 fi
 
+upgrade=
+if [ -n "$DD_UPGRADE" ]; then
+  upgrade=$DD_UPGRADE
+fi
+
+fips_mode=
+if [ -n "$DD_FIPS_MODE" ]; then
+  fips_mode=$DD_FIPS_MODE
+fi
+
+dd_env=
+if [ -n "$DD_ENV" ]; then
+    dd_env=$DD_ENV
+fi
+
+system_probe_ensure_config=
+if [ -n "$DD_SYSTEM_PROBE_ENSURE_CONFIG" ]; then
+  system_probe_ensure_config=$DD_SYSTEM_PROBE_ENSURE_CONFIG
+fi
+
+agent_flavor="datadog-agent"
+if [ -n "$DD_AGENT_FLAVOR" ]; then
+    agent_flavor=$DD_AGENT_FLAVOR #Eg: datadog-iot-agent
+fi
+
+
+##
+# INSTALL SCRIPT CONFIGURATION OPTIONS
+# Technical options to test with non production values for signature keys, packages or reporting telemetry.
+##
 if [ -n "$TESTING_KEYS_URL" ]; then
   keys_url=$TESTING_KEYS_URL
 else
@@ -370,21 +435,9 @@ if [ -n "$TESTING_REPORT_URL" ]; then
   telemetry_url=$TESTING_REPORT_URL
 fi
 
-upgrade=
-if [ -n "$DD_UPGRADE" ]; then
-  upgrade=$DD_UPGRADE
-fi
-
-fips_mode=
-if [ -n "$DD_FIPS_MODE" ]; then
-  fips_mode=$DD_FIPS_MODE
-fi
-
-dd_env=
-if [ -n "$DD_ENV" ]; then
-    dd_env=$DD_ENV
-fi
-
+##
+# APM SPECIFIC CONFIGURATION
+##
 declare -a apm_libraries
 declare host_injection_enabled
 declare docker_injection_enabled
@@ -474,46 +527,11 @@ if [ -n "$DD_APM_INSTRUMENTATION_NO_CONFIG_CHANGE" ]; then
   no_config_change="--no-config-change"
 fi
 
-system_probe_ensure_config=
-if [ -n "$DD_SYSTEM_PROBE_ENSURE_CONFIG" ]; then
-  system_probe_ensure_config=$DD_SYSTEM_PROBE_ENSURE_CONFIG
-fi
-
-agent_flavor="datadog-agent"
-if [ -n "$DD_AGENT_FLAVOR" ]; then
-    agent_flavor=$DD_AGENT_FLAVOR #Eg: datadog-iot-agent
-fi
-
-# Emulate hashmap with simple switch case
-function getMapData() {
-
-    if [ "$1" = "flavor_to_readable" ]; then
-        case "$2" in
-            "datadog-agent")
-                DATA="Datadog Agent"
-                ;;
-             "datadog-iot-agent")
-                DATA="Datadog IoT Agent"
-                ;;
-             "datadog-dogstatsd")
-                DATA="Datadog Dogstatsd"
-                ;;
-             "datadog-fips-proxy")
-                DATA="Datadog FIPS Proxy"
-                ;;
-             "datadog-heroku-agent")
-                DATA="Datadog Heroku Agent"
-                ;;
-              *)
-                DATA="Unknown"
-                ;;
-         esac
-    fi
-    printf '%s' "$DATA"
-}
+##
+# SETUP & VALIDATE CONFIGURATION
+##
 
 nice_flavor=$(getMapData flavor_to_readable "$agent_flavor")
-
 
 if [ -z "$nice_flavor" ]; then
     ERROR_MESSAGE="Unknown DD_AGENT_FLAVOR \"$agent_flavor\""
@@ -721,7 +739,9 @@ else
     sudo_cmd='sudo'
 fi
 
-# Install the necessary package sources
+##
+# INSTALL THE NECESSARY PACKAGE SOURCES
+##
 if [ "$OS" == "RedHat" ]; then
     remove_rpm_gpg_keys "$sudo_cmd" "${RPM_GPG_KEYS_TO_REMOVE[@]}"
     if { [ "$DISTRIBUTION" == "Rocky" ] || [ "$DISTRIBUTION" == "AlmaLinux" ]; } && { [ -n "$agent_minor_version_without_patch" ] && [ "$agent_minor_version_without_patch" -lt 33 ]; } && ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
@@ -1104,6 +1124,9 @@ https://app.datadoghq.com/account/settings#agent"
     exit;
 fi
 
+##
+# UPGRADE FROM AGENT 5
+##
 if [ -n "$upgrade" ] && [ "$agent_flavor" != "datadog-dogstatsd" ]; then
   if [ -e $LEGACY_CONF ]; then
     # try to import the config file from the previous version
@@ -1118,7 +1141,9 @@ if [ -n "$upgrade" ] && [ "$agent_flavor" != "datadog-dogstatsd" ]; then
   fi
 fi
 
-# Set the configuration
+##
+# SET THE CONFIGURATION
+##
 # Unit method
 function update_api_key() {
   local sudo_cmd="$1"
@@ -1345,6 +1370,9 @@ fi
 declare -a monitoring_services
 monitoring_services=( "datadog-agent" )
 
+##
+# START THE AGENT
+##
 if [ -n "$no_start" ]; then
   printf "\033[34m\n  * DD_INSTALL_ONLY environment variable set.\033[0m\n"
 fi


### PR DESCRIPTION
Added information about the install script configuration:
- Raised the behaviour with respect to existing configuration file
- Split options in 2 categories: for agent configuration and for install script itself. The latter ones should not be used by customer.
- Documented each option
- I mentioned OPW and vector install script but didn't gave much details.

You can review the README [here](https://github.com/DataDog/agent-linux-install-script/blob/nschweitzer/APL-1981/documentation/README.md) for more comfort.

This README will eventually be referenced from [Agent Install Instruction page](https://app.datadoghq.com/account/settings/agent/latest?platform=debian).
