### PR TITLE
[E2E] Install script e2e tests are fetching the latest available python version

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -21,6 +21,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type osConfig struct {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -110,8 +110,10 @@ func getEC2Options(t *testing.T) []ec2params.Option {
 
 func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) string {
 	path := fmt.Sprintf("/opt/%s/embedded/lib/python*", baseName)
+	fmt.Printf("Glob pattern : %s", path)
 	matches, err := filepath.Glob(path)
 	require.NoError(s.T(), err, fmt.Sprintf("Python embedded libraries not found at : %s", path))
+	require.NotEmpty(s.T(), matches)
 	latest := ""
 	var latestVersion *version.Version
 	for _, match := range matches {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -175,9 +175,7 @@ func (s *linuxInstallerTestSuite) addExtraIntegration() {
 	assert.NoError(t, err, "integration install failed")
 	pythonPath := s.getLatestEmbeddedPythonPath(s.baseName)
 	cmd := fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", pythonPath)
-	fmt.Printf("Exec : %s", cmd)
 	_ = vm.Execute(cmd)
-	fmt.Printf("Completed !")
 }
 
 func (s *linuxInstallerTestSuite) uninstall() {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -173,9 +173,7 @@ func (s *linuxInstallerTestSuite) addExtraIntegration() {
 	t.Log("Install an extra integration, and create a custom file")
 	_, err := vm.ExecuteWithError("sudo -u dd-agent -- datadog-agent integration install -t datadog-bind9==0.1.0")
 	assert.NoError(t, err, "integration install failed")
-	pythonPath := s.getLatestEmbeddedPythonPath(s.baseName)
-	cmd := fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", pythonPath)
-	_ = vm.Execute(cmd)
+	_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", s.getLatestEmbeddedPythonPath(s.baseName)))
 }
 
 func (s *linuxInstallerTestSuite) uninstall() {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -115,8 +115,8 @@ func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) s
 	var latestVersion version.Version
 	for _, match := range matches {
 		pythonVersion := strings.Split(match, "python")[1]
+		currentVers, versError := version.NewVersion(pythonVersion)
 		if latest != "" {
-			currentVers, versError := version.NewVersion(pythonVersion)
 			require.NoError(s.T(), versError, fmt.Sprintf("Invalid Python Version : %s", pythonVersion))
 			if currentVers.GreaterThan(latestVersion) {
 				latestVersion = currentVers
@@ -124,6 +124,7 @@ func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) s
 			}
 		} else {
 			latest = pythonVersion
+			latestVersion = currentVers
 		}
 	}
 	return fmt.Sprintf("/opt/%s/embedded/lib/python%s", baseName, latest)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -109,15 +108,14 @@ func getEC2Options(t *testing.T) []ec2params.Option {
 }
 
 func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) string {
-	path := fmt.Sprintf("/opt/%s/embedded/lib/python*", baseName)
-	fmt.Printf("Glob pattern : %s", path)
-	matches, err := filepath.Glob(path)
-	require.NoError(s.T(), err, fmt.Sprintf("Python embedded libraries not found at : %s", path))
-	require.NotEmpty(s.T(), matches)
+	vm := s.Env().VM
+	cmd := fmt.Sprintf("echo /opt/%s/embedded/lib/python*", baseName)
+	result, err := vm.ExecuteWithError(cmd)
+	require.NoError(s.T(), err, fmt.Sprintf("Python embedded libraries not found: %s", err))
+	require.NotEmpty(s.T(), result)
 	latest := ""
 	var latestVersion *version.Version
-	for _, match := range matches {
-		fmt.Printf("Match : %s", match)
+	for _, match := range strings.Split(result, " ") {
 		pythonVersion := strings.Split(match, "python")[1]
 		currentVers, versError := version.NewVersion(pythonVersion)
 		if latest != "" {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -115,6 +115,7 @@ func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) s
 	latest := ""
 	var latestVersion *version.Version
 	for _, match := range matches {
+		fmt.Printf("Match : %s", match)
 		pythonVersion := strings.Split(match, "python")[1]
 		currentVers, versError := version.NewVersion(pythonVersion)
 		if latest != "" {
@@ -128,6 +129,7 @@ func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) s
 			latestVersion = currentVers
 		}
 	}
+	require.NotEmpty(s.T(), latest)
 	return fmt.Sprintf("/opt/%s/embedded/lib/python%s", baseName, latest)
 }
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -204,7 +204,7 @@ func (s *linuxInstallerTestSuite) assertUninstall() {
 	assertFileExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, s.configFile))
 	if flavor == "datadog-agent" {
 		// The custom file should still be here. All other files, including the extra integration, should be removed
-		assertFileExists(t, vm, fmt.Sprintf("%s/site-packages/testfile", s.getLatestEmbeddedPythonPath(s.baseName)))
+		assertFileExists(t, vm, fmt.Sprintf("%s/site-packages/testfile", s.getLatestEmbeddedPythonPath("datadog-agent")))
 		files := strings.Split(strings.TrimSuffix(vm.Execute("find /opt/datadog-agent -type f"), "\n"), "\n")
 		assert.Len(t, files, 1, fmt.Sprintf("/opt/datadog-agent present after remove, found %v", files))
 	} else {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -129,6 +129,7 @@ func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) s
 			latestVersion = currentVers
 		}
 	}
+	latest = strings.ReplaceAll(latest, "\n", "")
 	require.NotEmpty(s.T(), latest)
 	stringOutput := fmt.Sprintf("/opt/%s/embedded/lib/python%s", baseName, latest)
 	return stringOutput

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -110,14 +110,13 @@ func getEC2Options(t *testing.T) []ec2params.Option {
 func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) string {
 	vm := s.Env().VM
 	cmd := fmt.Sprintf("echo /opt/%s/embedded/lib/python*", baseName)
-	fmt.Printf("Exec : %s\n", cmd)
 	result, err := vm.ExecuteWithError(cmd)
-	fmt.Printf("Get : %s\n", result)
 	require.NoError(s.T(), err, fmt.Sprintf("Python embedded libraries not found: %s", err))
 	require.NotEmpty(s.T(), result)
 	latest := ""
 	var latestVersion *version.Version
 	for _, match := range strings.Split(result, " ") {
+		fmt.Printf("for loop : %s\n", match)
 		pythonVersion := strings.Split(match, "python")[1]
 		currentVers, versError := version.NewVersion(pythonVersion)
 		if latest != "" {
@@ -132,6 +131,7 @@ func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) s
 		}
 	}
 	require.NotEmpty(s.T(), latest)
+	fmt.Printf("output : %s\n", fmt.Sprintf("/opt/%s/embedded/lib/python%s", baseName, latest))
 	return fmt.Sprintf("/opt/%s/embedded/lib/python%s", baseName, latest)
 }
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -110,7 +110,9 @@ func getEC2Options(t *testing.T) []ec2params.Option {
 func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) string {
 	vm := s.Env().VM
 	cmd := fmt.Sprintf("echo /opt/%s/embedded/lib/python*", baseName)
+	fmt.Printf("Exec : %s\n", cmd)
 	result, err := vm.ExecuteWithError(cmd)
+	fmt.Printf("Get : %s\n", result)
 	require.NoError(s.T(), err, fmt.Sprintf("Python embedded libraries not found: %s", err))
 	require.NotEmpty(s.T(), result)
 	latest := ""

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -108,6 +108,7 @@ func getEC2Options(t *testing.T) []ec2params.Option {
 }
 
 func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) string {
+	s.T().Helper()
 	vm := s.Env().VM
 	cmd := fmt.Sprintf("echo /opt/%s/embedded/lib/python*", baseName)
 	result, err := vm.ExecuteWithError(cmd)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -111,8 +111,8 @@ func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) s
 	path := fmt.Sprintf("/opt/%s/embedded/lib/python*", baseName)
 	matches, err := filepath.Glob(path)
 	require.NoError(s.T(), err, fmt.Sprintf("Python embedded libraries not found at : %s", path))
-	var latest string
-	var latestVersion version.Version
+	latest := ""
+	var latestVersion *version.Version
 	for _, match := range matches {
 		pythonVersion := strings.Split(match, "python")[1]
 		currentVers, versError := version.NewVersion(pythonVersion)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -173,8 +173,10 @@ func (s *linuxInstallerTestSuite) addExtraIntegration() {
 	_, err := vm.ExecuteWithError("sudo -u dd-agent -- datadog-agent integration install -t datadog-bind9==0.1.0")
 	assert.NoError(t, err, "integration install failed")
 	pythonPath := s.getLatestEmbeddedPythonPath(s.baseName)
-	fmt.Printf("pythonPath : %s", pythonPath)
-	_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", pythonPath))
+	cmd := fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", pythonPath)
+	fmt.Printf("Exec : %s", cmd)
+	_ = vm.Execute(cmd)
+	fmt.Printf("Completed !")
 }
 
 func (s *linuxInstallerTestSuite) uninstall() {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -116,7 +116,6 @@ func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) s
 	latest := ""
 	var latestVersion *version.Version
 	for _, match := range strings.Split(result, " ") {
-		fmt.Printf("for loop : %s\n", match)
 		pythonVersion := strings.Split(match, "python")[1]
 		currentVers, versError := version.NewVersion(pythonVersion)
 		if latest != "" {
@@ -131,8 +130,8 @@ func (s *linuxInstallerTestSuite) getLatestEmbeddedPythonPath(baseName string) s
 		}
 	}
 	require.NotEmpty(s.T(), latest)
-	fmt.Printf("output : %s\n", fmt.Sprintf("/opt/%s/embedded/lib/python%s", baseName, latest))
-	return fmt.Sprintf("/opt/%s/embedded/lib/python%s", baseName, latest)
+	stringOutput := fmt.Sprintf("/opt/%s/embedded/lib/python%s", baseName, latest)
+	return stringOutput
 }
 
 func (s *linuxInstallerTestSuite) assertInstallScript() {
@@ -173,7 +172,9 @@ func (s *linuxInstallerTestSuite) addExtraIntegration() {
 	t.Log("Install an extra integration, and create a custom file")
 	_, err := vm.ExecuteWithError("sudo -u dd-agent -- datadog-agent integration install -t datadog-bind9==0.1.0")
 	assert.NoError(t, err, "integration install failed")
-	_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", s.getLatestEmbeddedPythonPath(s.baseName)))
+	pythonPath := s.getLatestEmbeddedPythonPath(s.baseName)
+	fmt.Printf("pythonPath : %s", pythonPath)
+	_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", pythonPath))
 }
 
 func (s *linuxInstallerTestSuite) uninstall() {

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -5,8 +5,8 @@ go 1.20
 require (
 	github.com/DataDog/datadog-agent/test/new-e2e v0.49.0-rc.7
 	github.com/DataDog/test-infra-definitions v0.0.0-20231130165842-894572ece376
+	github.com/hashicorp/go-version v1.6.0
 	github.com/stretchr/testify v1.8.4
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -136,6 +136,7 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -228,6 +228,8 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.17.0 h1:z1XvSUyXd1HP10U4lrLg5e0JMVz6CPaJvAgxM0KNZVY=
 github.com/hashicorp/hcl/v2 v2.17.0/go.mod h1:gJyW2PTShkJqQBKpAmPO3yxMxIuoXkOF2TpqXzrQyx4=


### PR DESCRIPTION
Add the `getLatestEmbeddedPythonPath` function to fetch the path to the latest python version embedded into an agent