### PR TITLE
Invalidate install.datadoghq.com distribution on script release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - deploy
 
 variables:
+  AWS_MAX_ATTEMPTS: 5  # retry AWS operations 5 times if they fail on network errors
   DATADOG_AGENT_BUILDERS: v9930706-ef9d493
   DATADOG_AGENT_BUILDIMAGES: v13321514-644fed4
   S3_CP_CMD: aws s3 cp --only-show-errors --region us-east-1 --sse AES256
@@ -368,3 +369,15 @@ deploy:
       - SCRIPT: install_script_vector0.sh
   script:
     - $S3_CP_CMD ./${SCRIPT} s3://dd-agent/scripts/${SCRIPT} --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+  after_script:
+    # invalidate the install.datadoghq.com CF distribution
+    - export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s"
+        $(aws --region "us-east-1" sts assume-role
+          --duration-seconds 900
+          --role-arn "arn:aws:iam::464622532012:role/build-stable-cloudfront-invalidation"
+          --role-session-name "build-stable-cloudfront-invalidate-script"
+          --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]"
+          --output text
+        )
+      )
+    - aws --region "us-east-1" cloudfront create-invalidation --distribution-id "E2VSER0FO39KRV" --paths "/scripts/*"


### PR DESCRIPTION
I tested the invalidation in another [testing branch](https://github.com/DataDog/agent-linux-install-script/compare/slavek.kabrda/test-cf-invalidate?expand=1) (because the only way to test it fully would be to do an actual release).