### PR TITLE
chore: Update buildimages tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,9 +6,9 @@ stages:
   - deploy
 
 variables:
-  AWS_MAX_ATTEMPTS: 5  # retry AWS operations 5 times if they fail on network errors
+  AWS_MAX_ATTEMPTS: 5 # retry AWS operations 5 times if they fail on network errors
   DATADOG_AGENT_BUILDERS: v9930706-ef9d493
-  DATADOG_AGENT_BUILDIMAGES: v13321514-644fed4
+  DATADOG_AGENT_BUILDIMAGES: v28948509-c025473e
   S3_CP_CMD: aws s3 cp --only-show-errors --region us-east-1 --sse AES256
   TEST_INFRA_DEFINITIONS_BUILDIMAGES: 894572ece376
   DEFAULT_MAJOR_VERSION: 7
@@ -375,12 +375,12 @@ deploy:
   after_script:
     # invalidate the install.datadoghq.com CF distribution
     - export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s"
-        $(aws --region "us-east-1" sts assume-role
-          --duration-seconds 900
-          --role-arn "arn:aws:iam::464622532012:role/build-stable-cloudfront-invalidation"
-          --role-session-name "build-stable-cloudfront-invalidate-script"
-          --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]"
-          --output text
-        )
+      $(aws --region "us-east-1" sts assume-role
+      --duration-seconds 900
+      --role-arn "arn:aws:iam::464622532012:role/build-stable-cloudfront-invalidation"
+      --role-session-name "build-stable-cloudfront-invalidate-script"
+      --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]"
+      --output text
+      )
       )
     - aws --region "us-east-1" cloudfront create-invalidation --distribution-id "E2VSER0FO39KRV" --paths "/scripts/*"


### PR DESCRIPTION
I also don't see a _huge_ issue tracking `latest` here, and it would save us from having to update this regularly.

ref: https://github.com/DataDog/agent-linux-install-script/pull/24