### PR TITLE
fix: Update makefile and script metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ pre_release_%:
 	$(eval NEW_VERSION=$(shell echo "$@" | sed -e 's|pre_release_||'))
 	$(IN_PLACE_SED) -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script.sh.template
 	$(IN_PLACE_SED) -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script_op_worker1.sh
+	$(IN_PLACE_SED) -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script_op_worker2.sh
 	$(MAKE) update_changelog VERSION=${CUR_VERSION}
 	$(IN_PLACE_SED) -e "s|^Unreleased|${NEW_VERSION}|g" CHANGELOG.rst
 
@@ -79,6 +80,7 @@ pre_release_minor:
 	$(eval CUR_VERSION=$(shell echo "${CUR_VERSION}" | sed -e 's|.post||'))
 	$(IN_PLACE_SED) -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script.sh.template
 	$(IN_PLACE_SED) -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script_op_worker1.sh
+	$(IN_PLACE_SED) -e "s|install_script_version=.*|install_script_version=${NEW_VERSION}|g" install_script_op_worker2.sh
 	$(MAKE) update_changelog VERSION=${CUR_VERSION}
 	$(IN_PLACE_SED) -e "s|^Unreleased|${NEW_VERSION}|g" CHANGELOG.rst
 
@@ -96,6 +98,7 @@ post_release:
     endif
 	$(IN_PLACE_SED) -e "s|install_script_version=.*|install_script_version=${CUR_VERSION}.post|g" install_script.sh.template
 	$(IN_PLACE_SED) -e "s|install_script_version=.*|install_script_version=${CUR_VERSION}.post|g" install_script_op_worker1.sh
+	$(IN_PLACE_SED) -e "s|install_script_version=.*|install_script_version=${CUR_VERSION}.post|g" install_script_op_worker2.sh
 	echo "4i\n\nUnreleased\n================\n.\nw\nq" | ed -s CHANGELOG.rst
 
 tag:

--- a/install_script_op_worker2.sh
+++ b/install_script_op_worker2.sh
@@ -8,10 +8,10 @@
 
 set -e
 
-install_script_version=1.26.0.post
+install_script_version=1.27.0.post
 logfile="dd-install.log"
 support_email=support@datadoghq.com
-variant=install_script_op_worker1
+variant=install_script_op_worker2
 
 # DATADOG_APT_KEY_CURRENT.public always contains key used to sign current
 # repodata and newly released packages


### PR DESCRIPTION
- **fix: Add op_worker2 script to Makefile release targets**
- **fix: Update op_worker2 metadata**

These two places were missed when the v2 script was added recently.
