### PR TITLE
(fleet) uninstall datadog-agent when datadog-updater is installed

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1081,7 +1081,12 @@ If the cause is unclear, please contact Datadog support.
 
     if [ ${#packages_to_remove[@]} -ne 0 ]; then
       echo -e "  \033[33mRemoving package(s): ${packages_to_remove[*]}\n\033[0m"
-      $sudo_cmd apt-get remove -o Acquire::Retries="5" -y --force-yes "${packages_to_remove[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
+      for pkg in "${packages_to_remove[@]}"
+      do
+        if $sudo_cmd dpkg-query -l "$pkg" >/dev/null 2>&1; then
+          $sudo_cmd apt-get remove -o Acquire::Retries="5" -y --force-yes "${pkg}" 2> >(tee /tmp/ddog_install_error_msg >&2)
+        fi
+      done
     fi
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1046,6 +1046,7 @@ If the cause is unclear, please contact Datadog support.
     fi
 
     declare -a packages
+    declare -a packages_to_remove
     if [ -n "$no_agent" ]; then
       packages=("datadog-signing-keys")
     else
@@ -1053,6 +1054,7 @@ If the cause is unclear, please contact Datadog support.
     fi
     if [ -n "$install_updater" ]; then
       packages=("datadog-updater" "datadog-signing-keys")
+      packages_to_remove=("datadog-agent")
     fi
 
     if [ -n "$fips_mode" ]; then
@@ -1075,6 +1077,11 @@ If the cause is unclear, please contact Datadog support.
           $sudo_cmd dpkg --set-selections <<< "${cur_lib} install" >/dev/null 2>&1
         fi
       done
+    fi
+
+    if [ ${#packages_to_remove[@]} -ne 0 ]; then
+      echo -e "  \033[33mRemoving package(s): ${packages_to_remove[*]}\n\033[0m"
+      $sudo_cmd apt-get remove -o Acquire::Retries="5" -y --force-yes "${packages_to_remove[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
     fi
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,8 +1,6 @@
 module github.com/DataDog/agent-linux-install-script/test/e2e
 
-go 1.21
-
-toolchain go1.21.5
+go 1.20
 
 require (
 	github.com/DataDog/datadog-agent/test/new-e2e v0.49.0-rc.7

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,8 @@
 module github.com/DataDog/agent-linux-install-script/test/e2e
 
-go 1.20
+go 1.21
+
+toolchain go1.21.5
 
 require (
 	github.com/DataDog/datadog-agent/test/new-e2e v0.49.0-rc.7

--- a/test/e2e/install_updater_test.go
+++ b/test/e2e/install_updater_test.go
@@ -88,7 +88,7 @@ func (s *linuxInstallerTestSuite) assertPackageInstalled(pkg string, assertInsta
 	vm := s.Env().VM
 	var installed bool
 	if _, err := vm.ExecuteWithError("command -v apt"); err == nil {
-		if _, err := vm.ExecuteWithError(fmt.Sprintf("sudo dpkg-query -l \"%s\" >/dev/null 2>&1", pkg)); err == nil {
+		if _, err := vm.ExecuteWithError(fmt.Sprintf("dpkg-query -l \"%s\" >/dev/null 2>&1", pkg)); err == nil {
 			installed = true
 		}
 	} else if _, err = vm.ExecuteWithError("command -v yum"); err == nil {


### PR DESCRIPTION
This PR uninstalls the `datadog-agent` package when `datadog-updater` is installed.

Note that we want to keep the existing `datadog.yaml` during the uninstall so we explicitely do not `--purge`.