### PR TITLE
[BARX-289] fix updater ubuntu test + bootstrap config

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -418,9 +418,29 @@ if [ -n "$DD_AGENT_FLAVOR" ]; then
     agent_flavor=$DD_AGENT_FLAVOR #Eg: datadog-iot-agent
 fi
 
+# Root user detection
+if [ "$UID" == "0" ]; then
+    sudo_cmd=''
+else
+    sudo_cmd='sudo'
+fi
+
 install_updater=
 if [ -n "$DD_INSTALL_UPDATER" ]; then
     install_updater=true
+    config_file="/etc/datadog-agent/datadog.yaml"
+    if [ ! -e $config_file ]; then
+        $sudo_cmd mkdir -p /etc/datadog-agent
+        $sudo_cmd touch $config_file
+        $sudo_cmd chmod 666 $config_file # very bad practice, but unlocks internal trials
+        echo "api_key: $apikey" > $config_file
+        echo "site: $site" >> $config_file
+	echo "hostname: $hostname" >> $config_file
+        formatted_host_tags="['""$( echo "$host_tags" | sed "s/,/', '/g" )""']"  # format `env:prod,foo:bar` to yaml-compliant `['env:prod','foo:bar']`
+	echo "tags: $formatted_host_tags" >> $config_file
+	echo "env: $env" >> $config_file
+	echo "dd_url: $url" >> $config_file
+    fi
 fi
 
 
@@ -909,7 +929,6 @@ if [ "$OS" == "RedHat" ]; then
     else
       packages=("$agent_flavor")
     fi
-
     if [ -n "$fips_mode" ]; then
       packages+=("datadog-fips-proxy")
     fi
@@ -1053,6 +1072,7 @@ If the cause is unclear, please contact Datadog support.
     fi
     if [ -n "$install_updater" ]; then
       packages=("datadog-updater" "datadog-signing-keys")
+      services=()
     fi
 
     if [ -n "$fips_mode" ]; then

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -418,29 +418,9 @@ if [ -n "$DD_AGENT_FLAVOR" ]; then
     agent_flavor=$DD_AGENT_FLAVOR #Eg: datadog-iot-agent
 fi
 
-# Root user detection
-if [ "$UID" == "0" ]; then
-    sudo_cmd=''
-else
-    sudo_cmd='sudo'
-fi
-
 install_updater=
 if [ -n "$DD_INSTALL_UPDATER" ]; then
     install_updater=true
-    config_file="/etc/datadog-agent/datadog.yaml"
-    if [ ! -e $config_file ]; then
-        $sudo_cmd mkdir -p /etc/datadog-agent
-        $sudo_cmd touch $config_file
-        $sudo_cmd chmod 644 $config_file
-        echo "api_key: $apikey" > $config_file
-        echo "site: $site" >> $config_file
-	echo "hostname: $hostname" >> $config_file
-        formatted_host_tags="['""$( echo "$host_tags" | sed "s/,/', '/g" )""']"  # format `env:prod,foo:bar` to yaml-compliant `['env:prod','foo:bar']`
-	echo "tags: $formatted_host_tags" >> $config_file
-	echo "env: $env" >> $config_file
-	echo "dd_url: $url" >> $config_file
-    fi
 fi
 
 
@@ -1073,6 +1053,19 @@ If the cause is unclear, please contact Datadog support.
     if [ -n "$install_updater" ]; then
       packages=("datadog-updater" "datadog-signing-keys")
       services=()
+      config_file="/etc/datadog-agent/datadog.yaml"
+      if [ ! -e $config_file ]; then
+        $sudo_cmd mkdir -p /etc/datadog-agent
+        $sudo_cmd touch $config_file
+        $sudo_cmd chmod 644 $config_file
+        echo "api_key: $apikey" > $config_file
+        echo "site: $site" >> $config_file
+	echo "hostname: $hostname" >> $config_file
+        formatted_host_tags="['""$( echo "$host_tags" | sed "s/,/', '/g" )""']"  # format `env:prod,foo:bar` to yaml-compliant `['env:prod','foo:bar']`
+	echo "tags: $formatted_host_tags" >> $config_file
+	echo "env: $env" >> $config_file
+	echo "dd_url: $url" >> $config_file
+      fi
     fi
 
     if [ -n "$fips_mode" ]; then

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1052,6 +1052,9 @@ If the cause is unclear, please contact Datadog support.
       packages=("$agent_flavor" "datadog-signing-keys")
     fi
     if [ -n "$install_updater" ]; then
+      # this feature is experimental
+      # and will generate a datadog.yaml config file if it doesn't exist
+      # ignoring further configuration logic in this script
       packages=("datadog-updater" "datadog-signing-keys")
       services=()
       config_file="/etc/datadog-agent/datadog.yaml"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -909,6 +909,7 @@ if [ "$OS" == "RedHat" ]; then
     else
       packages=("$agent_flavor")
     fi
+
     if [ -n "$fips_mode" ]; then
       packages+=("datadog-fips-proxy")
     fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -432,7 +432,7 @@ if [ -n "$DD_INSTALL_UPDATER" ]; then
     if [ ! -e $config_file ]; then
         $sudo_cmd mkdir -p /etc/datadog-agent
         $sudo_cmd touch $config_file
-        $sudo_cmd chmod 666 $config_file # very bad practice, but unlocks internal trials
+        $sudo_cmd chmod 644 $config_file
         echo "api_key: $apikey" > $config_file
         echo "site: $site" >> $config_file
 	echo "hostname: $hostname" >> $config_file

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1059,13 +1059,13 @@ If the cause is unclear, please contact Datadog support.
         $sudo_cmd mkdir -p /etc/datadog-agent
         $sudo_cmd touch $config_file
         $sudo_cmd chmod 644 $config_file
-        echo "api_key: $apikey" > $config_file
-        echo "site: $site" >> $config_file
-	echo "hostname: $hostname" >> $config_file
+        $sudo_cmd sh -c "echo 'api_key: $apikey' > $config_file"
+        $sudo_cmd sh -c "echo 'site: $site' >> $config_file"
+        $sudo_cmd sh -c "echo 'hostname: $hostname' >> $config_file"
         formatted_host_tags="['""$( echo "$host_tags" | sed "s/,/', '/g" )""']"  # format `env:prod,foo:bar` to yaml-compliant `['env:prod','foo:bar']`
-	echo "tags: $formatted_host_tags" >> $config_file
-	echo "env: $env" >> $config_file
-	echo "dd_url: $url" >> $config_file
+        $sudo_cmd sh -c "echo 'tags: $formatted_host_tags' >> $config_file"
+        $sudo_cmd sh -c "echo 'env: $env' >> $config_file"
+        $sudo_cmd sh -c "echo 'dd_url: $url' >> $config_file"
       fi
     fi
 


### PR DESCRIPTION
The ubuntu tests failed as systemd units entered a failed state due to missing datadog.yaml. Having a datadog.yaml before installing the updater is necessary to ensure that the updater knows what to install.
Customers can set rules such as: install agent version 7.51 on env prod

Fixes

Create an early datadog.yaml in the case of the updater
Ignore services restart on updater installation