### PR TITLE
[test] retry failed test jobs on failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,8 @@ unit_tests:
     SCRIPT: "install_script_agent${MAJOR_VERSION}.sh"
   script:
     - ./test/localtest.sh
+  # retry the job in case of failure, we might have network issues downloading the image
+  retry: 2
 
 test_pinned_version:
   extends: .test


### PR DESCRIPTION
Add retries on `test` jobs, we can have network issues downloading the target image from the runner https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/463846872