### PR TITLE
chore: Clarify usage of script configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ The install script allows installation of different flavors of the Agent binarie
 
 
 ## Install script configuration options
-The install script also comes with its own configuration options for testing purpose.
+The install script also comes with its own configuration options.
 
 >[!WARNING]
-> These options are intended for Datadog internal use only.
+>Options prefixed with `TESTING_` are intended for Datadog internal use only.
 
 | Variable | Description|
 |-|-|


### PR DESCRIPTION
I noticed the README suggested that all of the script options were for internal testing purposes only, however this is not the case. We have a number of variables prefixed with `TESTING_` which are (almost) exclusively used in our testing internally, however several of the listed variables can/should be used by customers (to pin the minor version when installing, for example).
