### PR TITLE
Install Old 2022 RPM GPG key only when needed for agent <= 7.35

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -300,6 +300,17 @@ function remove_rpm_gpg_keys() {
     done
 }
 
+function get_relevant_gpg_keys() {
+    local minorVersion="$1"
+    shift
+    local gpgKeys=("$@")
+    # The last GPG key is only used on agent 7.35.X and lower
+    if [ "minorVersion" -gt 35 ]; then
+        gpgKeys=("${gpgKeys[@]/$gpgKeys[3]}")
+    fi
+    echo "${gpgKeys[@]}"
+}
+
 # Emulate hashmap with simple switch case
 function getMapData() {
 
@@ -876,7 +887,7 @@ if [ "$OS" == "RedHat" ]; then
 
     gpgkeys=''
     separator='\n       '
-    for key_path in "${RPM_GPG_KEYS[@]}"; do
+    for key_path in $(get_relevant_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
       gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
     done
 
@@ -1156,12 +1167,12 @@ elif [ "$OS" == "SUSE" ]; then
   echo -e "\033[34m\n* Importing the Datadog GPG Keys\n\033[0m"
   if [ "$SUSE11" == "yes" ]; then
     # SUSE 11 special case
-    for key_path in "${RPM_GPG_KEYS[@]}"; do
+    for key_path in $(get_relevant_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
       $sudo_cmd curl -sSL --retry 5 -o "/tmp/${key_path}" "https://${keys_url}/${key_path}"
       $sudo_cmd rpm --import "/tmp/${key_path}"
     done
   else
-    for key_path in "${RPM_GPG_KEYS[@]}"; do
+    for key_path in $(get_relevant_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
       $sudo_cmd rpm --import "https://${keys_url}/${key_path}"
     done
   fi
@@ -1175,7 +1186,7 @@ elif [ "$OS" == "SUSE" ]; then
   if [ -n "$SUSE_VER" ] && [ "$SUSE_VER" -ge 15 ] && [ "$SUSE_VER" -ne 42 ]; then
     gpgkeys=''
     separator='\n       '
-    for key_path in "${RPM_GPG_KEYS[@]}"; do
+    for key_path in $(get_relevant_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
       gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
     done
   fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -305,7 +305,7 @@ function get_relevant_gpg_keys() {
     shift
     local gpgKeys=("$@")
     # The last GPG key is only used on agent 7.35.X and lower
-    if [ "minorVersion" -gt 35 ] || [ -z "$minorVersion" ]; then
+    if [ -z "$minorVersion" ] || [ "$minorVersion" -gt 35 ]; then
         gpgKeys=("${gpgKeys[@]/$gpgKeys[3]}")
     fi
     echo "${gpgKeys[@]}"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -306,7 +306,7 @@ function get_relevant_gpg_keys() {
     local gpgKeys=("$@")
     # The last GPG key is only used on agent 7.35.X and lower
     if [ -z "$minorVersion" ] || [ "$minorVersion" -gt 35 ]; then
-        gpgKeys=("${gpgKeys[@]/$gpgKeys[3]}")
+        unset 'gpgKeys[${#gpgKeys[@]}-1]'
     fi
     echo "${gpgKeys[@]}"
 }

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -305,7 +305,7 @@ function get_relevant_gpg_keys() {
     shift
     local gpgKeys=("$@")
     # The last GPG key is only used on agent 7.35.X and lower
-    if [ "minorVersion" -gt 35 ]; then
+    if [ "minorVersion" -gt 35 ] || [ -z "$minorVersion" ]; then
         gpgKeys=("${gpgKeys[@]/$gpgKeys[3]}")
     fi
     echo "${gpgKeys[@]}"


### PR DESCRIPTION
Pop the last GPG key (expired in 2022) from the `RPM_GPG_KEYS` to install if we're not using an agent <= 7.35  