### PR TITLE
Add --no-refresh to zypper invocations

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1282,9 +1282,9 @@ elif [ "$OS" == "SUSE" ]; then
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
     # Not yet retry mechanism in zypper, see https://github.com/openSUSE/zypper/issues/420
     if [ -z "$sudo_cmd" ]; then
-      ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:
+      ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:
     else
-      $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:
+      $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:
     fi
 
     ERR_SUMMARY=$(grep "Write error" -C1 /tmp/ddog_install_error_msg || true)
@@ -1292,8 +1292,7 @@ elif [ "$OS" == "SUSE" ]; then
     echo -e "  \033[33mNo packages to install.\033[0m\n"
   fi
 
-  # If zypper fails to refresh a random repo, it installs the package, but then fails
-  # anyway. Therefore we let it do its thing and then see if curl was installed or not.
+  # Confirm the packages were installed
   for expected_pkg in "${packages[@]}"; do
     if ! rpm -q "${expected_pkg}" > /dev/null; then
       ERROR_MESSAGE="Failed to install ${expected_pkg}."


### PR DESCRIPTION
We've been having some flakes on e2e tests for the install script ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/488660351#L1035)).

The culprit seems to be related failure during autorefresh when installing. Adding `--no-refresh` should prevent the autorefresh from happening, removing that chance of error. I didn't add the `--no-refresh` to `install curl` since the autorefresh may be useful there and it's only done when curl doesn't already exist which is probably not very typical.

Official docs for this option under https://en.opensuse.org/SDB:Zypper_manual#GLOBAL_OPTIONS.