### PR TITLE
Add missing env vars to OP 2.0 script

### DIFF
--- a/install_script_op_worker2.sh
+++ b/install_script_op_worker2.sh
@@ -151,12 +151,12 @@ fi
 
 apikey=
 if [ -n "$DD_API_KEY" ]; then
-    apikey=$DD_API_KEY
+    apikey="$DD_API_KEY"
 fi
 
 op_pipeline_id=
 if [ -n "$DD_OP_PIPELINE_ID" ]; then
-    op_pipeline_id=$DD_OP_PIPELINE_ID
+    op_pipeline_id="$DD_OP_PIPELINE_ID"
 fi
 
 no_start=
@@ -167,59 +167,59 @@ fi
 # sources
 source_splunk_hec_address=
 if [ -n "$DD_OP_SOURCE_SPLUNK_HEC_ADDRESS" ]; then
-    source_splunk_hec_address=$DD_OP_SOURCE_SPLUNK_HEC_ADDRESS
+    source_splunk_hec_address="$DD_OP_SOURCE_SPLUNK_HEC_ADDRESS"
 fi
 
 source_splunk_tcp_address=
 if [ -n "$DD_OP_SOURCE_SPLUNK_TCP_ADDRESS" ]; then
-    source_splunk_tcp_address=$DD_OP_SOURCE_SPLUNK_TCP_ADDRESS
+    source_splunk_tcp_address="$DD_OP_SOURCE_SPLUNK_TCP_ADDRESS"
 fi
 
 source_datadog_agent_address=
 if [ -n "$DD_OP_SOURCE_DATADOG_AGENT_ADDRESS" ]; then
-    source_datadog_agent_address=$DD_OP_SOURCE_DATADOG_AGENT_ADDRESS
+    source_datadog_agent_address="$DD_OP_SOURCE_DATADOG_AGENT_ADDRESS"
 fi
 
 source_sumo_logic_address=
 if [ -n "$DD_OP_SOURCE_SUMO_LOGIC_ADDRESS" ]; then
-    source_sumo_logic_address=$DD_OP_SOURCE_SUMO_LOGIC_ADDRESS
+    source_sumo_logic_address="$DD_OP_SOURCE_SUMO_LOGIC_ADDRESS"
 fi
 
 # source key passes
 source_splunk_tcp_key_pass=
 if [ -n "$DD_OP_SOURCE_SPLUNK_TCP_KEY_PASS" ]; then
-    source_splunk_tcp_key_pass=$DD_OP_SOURCE_SPLUNK_TCP_KEY_PASS
+    source_splunk_tcp_key_pass="$DD_OP_SOURCE_SPLUNK_TCP_KEY_PASS"
 fi
 
 source_splunk_hec_key_pass=
 if [ -n "$DD_OP_SOURCE_SPLUNK_HEC_KEY_PASS" ]; then
-    source_splunk_hec_key_pass=$DD_OP_SOURCE_SPLUNK_HEC_KEY_PASS
+    source_splunk_hec_key_pass="$DD_OP_SOURCE_SPLUNK_HEC_KEY_PASS"
 fi
 
 # destinations
 dest_splunk_hec_endpoint=
 if [ -n "$DD_OP_DESTINATION_SPLUNK_HEC_ENDPOINT_URL" ]; then
-    dest_splunk_hec_endpoint=$DD_OP_DESTINATION_SPLUNK_HEC_ENDPOINT_URL
+    dest_splunk_hec_endpoint="$DD_OP_DESTINATION_SPLUNK_HEC_ENDPOINT_URL"
 fi
 
 dest_splunk_hec_token=
 if [ -n "$DD_OP_DESTINATION_SPLUNK_HEC_TOKEN" ]; then
-    dest_splunk_hec_token=$DD_OP_DESTINATION_SPLUNK_HEC_TOKEN
+    dest_splunk_hec_token="$DD_OP_DESTINATION_SPLUNK_HEC_TOKEN"
 fi
 
 dest_sumo_logic_endpoint=
 if [ -n "$DD_OP_DESTINATION_SUMO_LOGIC_HTTP_COLLECTOR_URL" ]; then
-    dest_sumo_logic_endpoint=$DD_OP_DESTINATION_SUMO_LOGIC_HTTP_COLLECTOR_URL
+    dest_sumo_logic_endpoint="$DD_OP_DESTINATION_SUMO_LOGIC_HTTP_COLLECTOR_URL"
 fi
 
 dest_datadog_archives_aws_key_id=
 if [ -n "$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_ACCESS_KEY_ID" ]; then
-    dest_datadog_archives_aws_key_id=$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_ACCESS_KEY_ID
+    dest_datadog_archives_aws_key_id="$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_ACCESS_KEY_ID"
 fi
 
 dest_datadog_archives_aws_secret=
 if [ -n "$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_SECRET_ACCESS_KEY" ]; then
-    dest_datadog_archives_aws_secret=$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_SECRET_ACCESS_KEY
+    dest_datadog_archives_aws_secret="$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_SECRET_ACCESS_KEY"
 fi
 
 if [ -n "$DD_REPO_URL" ]; then

--- a/install_script_op_worker2.sh
+++ b/install_script_op_worker2.sh
@@ -164,6 +164,64 @@ if [ -n "$DD_INSTALL_ONLY" ]; then
     no_start=true
 fi
 
+# sources
+source_splunk_hec_address=
+if [ -n "$DD_OP_SOURCE_SPLUNK_HEC_ADDRESS" ]; then
+    source_splunk_hec_address=$DD_OP_SOURCE_SPLUNK_HEC_ADDRESS
+fi
+
+source_splunk_tcp_address=
+if [ -n "$DD_OP_SOURCE_SPLUNK_TCP_ADDRESS" ]; then
+    source_splunk_tcp_address=$DD_OP_SOURCE_SPLUNK_TCP_ADDRESS
+fi
+
+source_datadog_agent_address=
+if [ -n "$DD_OP_SOURCE_DATADOG_AGENT_ADDRESS" ]; then
+    source_datadog_agent_address=$DD_OP_SOURCE_DATADOG_AGENT_ADDRESS
+fi
+
+source_sumo_logic_address=
+if [ -n "$DD_OP_SOURCE_SUMO_LOGIC_ADDRESS" ]; then
+    source_sumo_logic_address=$DD_OP_SOURCE_SUMO_LOGIC_ADDRESS
+fi
+
+# source key passes
+source_splunk_tcp_key_pass=
+if [ -n "$DD_OP_SOURCE_SPLUNK_TCP_KEY_PASS" ]; then
+    source_splunk_tcp_key_pass=$DD_OP_SOURCE_SPLUNK_TCP_KEY_PASS
+fi
+
+source_splunk_hec_key_pass=
+if [ -n "$DD_OP_SOURCE_SPLUNK_HEC_KEY_PASS" ]; then
+    source_splunk_hec_key_pass=$DD_OP_SOURCE_SPLUNK_HEC_KEY_PASS
+fi
+
+# destinations
+dest_splunk_hec_endpoint=
+if [ -n "$DD_OP_DESTINATION_SPLUNK_HEC_ENDPOINT_URL" ]; then
+    dest_splunk_hec_endpoint=$DD_OP_DESTINATION_SPLUNK_HEC_ENDPOINT_URL
+fi
+
+dest_splunk_hec_token=
+if [ -n "$DD_OP_DESTINATION_SPLUNK_HEC_TOKEN" ]; then
+    dest_splunk_hec_token=$DD_OP_DESTINATION_SPLUNK_HEC_TOKEN
+fi
+
+dest_sumo_logic_endpoint=
+if [ -n "$DD_OP_DESTINATION_SUMO_LOGIC_HTTP_COLLECTOR_URL" ]; then
+    dest_sumo_logic_endpoint=$DD_OP_DESTINATION_SUMO_LOGIC_HTTP_COLLECTOR_URL
+fi
+
+dest_datadog_archives_aws_key_id=
+if [ -n "$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_ACCESS_KEY_ID" ]; then
+    dest_datadog_archives_aws_key_id=$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_ACCESS_KEY_ID
+fi
+
+dest_datadog_archives_aws_secret=
+if [ -n "$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_SECRET_ACCESS_KEY" ]; then
+    dest_datadog_archives_aws_secret=$DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_SECRET_ACCESS_KEY
+fi
+
 if [ -n "$DD_REPO_URL" ]; then
     repository_url=$DD_REPO_URL
 elif [ -n "$REPO_URL" ]; then
@@ -474,6 +532,64 @@ else
   if [ "$site" ]; then
     printf "\033[34m  * Assigning DD_SITE.\n\033[0m\n"
     $sudo_cmd sh -c "echo DD_SITE=$site >> $env_file"
+  fi
+
+  # sources
+  if [ "$source_splunk_hec_address" ]; then
+    printf "\033[34m  * Assigning DD_OP_SOURCE_SPLUNK_HEC_ADDRESS.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_SOURCE_SPLUNK_HEC_ADDRESS=$source_splunk_hec_address>> $env_file"
+  fi
+
+  if [ "$source_splunk_tcp_address" ]; then
+    printf "\033[34m  * Assigning DD_OP_SOURCE_SPLUNK_TCP_ADDRESS.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_SOURCE_SPLUNK_TCP_ADDRESS=$source_splunk_tcp_address>> $env_file"
+  fi
+
+  if [ "$source_datadog_agent_address" ]; then
+    printf "\033[34m  * Assigning DD_OP_SOURCE_DATADOG_AGENT_ADDRESS.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_SOURCE_DATADOG_AGENT_ADDRESS=$source_datadog_agent_address>> $env_file"
+  fi
+
+  if [ "$source_sumo_logic_address" ]; then
+    printf "\033[34m  * Assigning DD_OP_SOURCE_SUMO_LOGIC_ADDRESS.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_SOURCE_SUMO_LOGIC_ADDRESS=$source_sumo_logic_address>> $env_file"
+  fi
+
+  # source key passes
+  if [ "$source_splunk_tcp_key_pass" ]; then
+    printf "\033[34m  * Assigning DD_OP_SOURCE_SPLUNK_TCP_KEY_PASS.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_SOURCE_SPLUNK_TCP_KEY_PASS=$source_splunk_tcp_key_pass>> $env_file"
+  fi
+
+  if [ "$source_splunk_hec_key_pass" ]; then
+    printf "\033[34m  * Assigning DD_OP_SOURCE_SPLUNK_HEC_KEY_PASS.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_SOURCE_SPLUNK_HEC_KEY_PASS=$source_splunk_hec_key_pass>> $env_file"
+  fi
+
+  # destinations
+  if [ "$dest_splunk_hec_endpoint" ]; then
+    printf "\033[34m  * Assigning DD_OP_DESTINATION_SPLUNK_HEC_ENDPOINT_URL.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_DESTINATION_SPLUNK_HEC_ENDPOINT_URL=$dest_splunk_hec_endpoint>> $env_file"
+  fi
+
+  if [ "$dest_splunk_hec_token" ]; then
+    printf "\033[34m  * Assigning DD_OP_DESTINATION_SPLUNK_HEC_TOKEN.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_DESTINATION_SPLUNK_HEC_TOKEN=$dest_splunk_hec_token>> $env_file"
+  fi
+
+  if [ "$dest_sumo_logic_endpoint" ]; then
+    printf "\033[34m  * Assigning DD_OP_DESTINATION_SUMO_LOGIC_HTTP_COLLECTOR_URL.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_DESTINATION_SUMO_LOGIC_HTTP_COLLECTOR_URL=$dest_sumo_logic_endpoint>> $env_file"
+  fi
+
+  if [ "$dest_datadog_archives_aws_key_id" ]; then
+    printf "\033[34m  * Assigning DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_ACCESS_KEY_ID.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_ACCESS_KEY_ID=$dest_datadog_archives_aws_key_id>> $env_file"
+  fi
+
+  if [ "$dest_datadog_archives_aws_secret" ]; then
+    printf "\033[34m  * Assigning DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_SECRET_ACCESS_KEY.\n\033[0m\n"
+    $sudo_cmd sh -c "echo DD_OP_DESTINATION_DATADOG_ARCHIVES_AWS_SECRET_ACCESS_KEY=$dest_datadog_archives_aws_secret>> $env_file"
   fi
 fi
 


### PR DESCRIPTION
During OP 2.0 development in Q1 2024 we added a number of env vars that need to be supported in the install script.

This is a first pass hard coded solution.