### PR TITLE
Revert "Install Old 2022 RPM GPG key only when needed for agent <= 7.35"

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -300,36 +300,6 @@ function remove_rpm_gpg_keys() {
     done
 }
 
-function versionlte() {
-    [  "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
-}
-
-function versionlt() {
-    ([ "$1" = "$2" ] && return 1) || versionlte "$1" "$2"
-}
-
-function get_relevant_rpm_gpg_keys() {
-    local minorVersion="$1"
-    shift
-    local gpgKeys=("$@")
-    # The last GPG key is only used on agent 7.35.X and lower
-    if [ -z "$minorVersion" ] || versionlt 35 "$minorVersion"; then
-        unset 'gpgKeys[${#gpgKeys[@]}-1]'
-    fi
-    echo "${gpgKeys[@]}"
-}
-
-function get_relevant_apt_gpg_keys() {
-    local minorVersion="$1"
-    shift
-    local gpgKeys=("$@")
-    # The last GPG key is only used on agent 7.35.X and lower
-    if [ -z "$minorVersion" ] || versionlt 35 "$minorVersion"; then
-        unset 'gpgKeys[${#gpgKeys[@]}-1]'
-    fi
-    echo "${gpgKeys[@]}"
-}
-
 # Emulate hashmap with simple switch case
 function getMapData() {
 
@@ -1110,7 +1080,7 @@ if [ "$OS" == "RedHat" ]; then
 
     gpgkeys=''
     separator='\n       '
-    for key_path in $(get_relevant_rpm_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
+    for key_path in "${RPM_GPG_KEYS[@]}"; do
       gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
     done
 
@@ -1226,7 +1196,7 @@ elif [ "$OS" == "Debian" ]; then
     # can read our keyring
     $sudo_cmd chmod a+r $apt_usr_share_keyring
 
-    for key in $(get_relevant_apt_gpg_keys "$agent_minor_version" "${APT_GPG_KEYS[@]}"); do
+    for key in "${APT_GPG_KEYS[@]}"; do
         $sudo_cmd curl -sSL --retry 5 -o "/tmp/${key}" "https://${keys_url}/${key}"
         $sudo_cmd cat "/tmp/${key}" | $sudo_cmd gpg --import --batch --no-default-keyring --keyring "$apt_usr_share_keyring"
     done
@@ -1370,12 +1340,12 @@ elif [ "$OS" == "SUSE" ]; then
   echo -e "\033[34m\n* Importing the Datadog GPG Keys\n\033[0m"
   if [ "$SUSE11" == "yes" ]; then
     # SUSE 11 special case
-    for key_path in $(get_relevant_rpm_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
+    for key_path in "${RPM_GPG_KEYS[@]}"; do
       $sudo_cmd curl -sSL --retry 5 -o "/tmp/${key_path}" "https://${keys_url}/${key_path}"
       $sudo_cmd rpm --import "/tmp/${key_path}"
     done
   else
-    for key_path in $(get_relevant_rpm_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
+    for key_path in "${RPM_GPG_KEYS[@]}"; do
       $sudo_cmd rpm --import "https://${keys_url}/${key_path}"
     done
   fi
@@ -1389,7 +1359,7 @@ elif [ "$OS" == "SUSE" ]; then
   if [ -n "$SUSE_VER" ] && [ "$SUSE_VER" -ge 15 ] && [ "$SUSE_VER" -ne 42 ]; then
     gpgkeys=''
     separator='\n       '
-    for key_path in $(get_relevant_rpm_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
+    for key_path in "${RPM_GPG_KEYS[@]}"; do
       gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
     done
   fi

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -7,9 +7,7 @@ package e2e
 
 import (
 	"fmt"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
 	"github.com/stretchr/testify/assert"
-	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
@@ -39,15 +37,11 @@ func (s *installTestSuite) TestInstall() {
 
 	s.assertInstallScript()
 
-	s.assertGPGKeys(false)
-
 	s.addExtraIntegration()
 
 	s.uninstall()
 
 	s.assertUninstall()
-
-	s.purgeGPGKeys()
 
 	s.purge()
 
@@ -60,52 +54,15 @@ func (s *installTestSuite) TestInstallMinorVersionPin() {
 
 	s.assertPinnedInstallScript("7.42.0")
 
-	s.assertGPGKeys(false)
-
 	s.addExtraIntegration()
 
 	s.uninstall()
 
 	s.assertUninstall()
 
-	s.purgeGPGKeys()
-
 	s.purge()
 
 	s.assertPurge()
-}
-
-func (s *installTestSuite) TestInstallMinorLowestVersionPin() {
-	var lowestVersion string
-	osPlatform := osConfigByPlatform[platform]
-	if osPlatform.osType == ec2os.DebianOS {
-		lowestVersion = "26.0"
-	} else {
-		lowestVersion = "16.0"
-	}
-
-	t := s.T()
-	vm := s.Env().VM
-
-	if flavor != "datadog-agent" {
-		t.Skip("TestInstallMinorLowestVersionPin is only tested on datadog-agent")
-	}
-
-	// Installation
-	s.InstallAgent(7, fmt.Sprintf("DD_AGENT_MINOR_VERSION=%s", lowestVersion), fmt.Sprintf("Install Agent 7 pinned to 7.%s", lowestVersion))
-
-	s.assertGPGKeys(true)
-
-	if flavor == "datadog-agent" {
-		_, err := vm.ExecuteWithError(fmt.Sprintf("sudo datadog-agent status | grep %s", fmt.Sprintf("7.%s", lowestVersion)))
-		assert.NoError(t, err)
-	}
-
-	s.uninstall()
-
-	s.purgeGPGKeys()
-
-	s.purge()
 }
 
 func (s *installTestSuite) assertPinnedInstallScript(pinVersion string) {
@@ -136,40 +93,4 @@ func (s *installTestSuite) assertInstallScript() {
 	assertFileNotExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, securityAgentConfigFileName))
 	assertFileNotExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
 	assertFileNotExists(t, vm, fipsConfigFilepath)
-}
-
-func (s *installTestSuite) assertGPGKeys(allKeysNeeded bool) {
-	t := s.T()
-	vm := s.Env().VM
-
-	if osConfigByPlatform[platform].osType == ec2os.DebianOS || osConfigByPlatform[platform].osType == ec2os.UbuntuOS {
-		output, err := vm.ExecuteWithError("apt-key --keyring /usr/share/keyrings/datadog-archive-keyring.gpg list 2>/dev/null | grep -oE [0-9A-Z\\ ]{9}$")
-		t.Log(output)
-		assert.NoError(t, err)
-		// assert.Equal(t, allKeysNeeded, strings.Contains(output, "382E 94DE")) TODO: datadog-signing-keys for now is installing expired key on package install
-		assert.True(t, strings.Contains(output, "F14F 620E"))
-		assert.True(t, strings.Contains(output, "C096 2C7D"))
-	} else {
-		output, err := vm.ExecuteWithError("rpm -qa gpg-pubkey*")
-		t.Log(output)
-		assert.NoError(t, err)
-		assert.Equal(t, allKeysNeeded, strings.Contains(output, "e09422b3"))
-		assert.True(t, strings.Contains(output, "fd4bf915"))
-		assert.True(t, strings.Contains(output, "b01082d3"))
-	}
-}
-
-func (s *installTestSuite) purgeGPGKeys() {
-	t := s.T()
-	vm := s.Env().VM
-
-	t.Log("Purge GPG Keys")
-
-	if osConfigByPlatform[platform].osType == ec2os.DebianOS || osConfigByPlatform[platform].osType == ec2os.UbuntuOS {
-		_, _ = vm.ExecuteWithError("sudo rm /usr/share/keyrings/datadog-archive-keyring.gpg || true")
-		_, _ = vm.ExecuteWithError("sudo rm /etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg || true")
-	} else {
-		_, err := vm.ExecuteWithError("for gpgkey in $(rpm -qa gpg-pubkey*); do sudo rpm -e $gpgkey; done")
-		assert.NoError(t, err)
-	}
 }


### PR DESCRIPTION
Reverts DataDog/agent-linux-install-script#174