### PR TITLE
(fleet) improve the installer install script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -315,6 +315,10 @@ e2e:
       - FLAVOR: datadog-agent
         PLATFORM:
           - Debian_11
+          - Ubuntu_22_04
+          - RedHat_CentOS_7
+          - RedHat_8
+          - Amazon_Linux_2023
         EXTRA_PARAMS:
           - --run TestInstallUpdaterSuite
       - FLAVOR: datadog-agent

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -502,7 +502,8 @@ function _install_installer() {
     local sudo_cmd="$1"
     local os="$2"
     local distribution="$3"
-    local apm_instrumentation_enabled="$4"
+    local datadog_installer="$4"
+    local apm_instrumentation_enabled="$5"
 
     # The installer is currently only being rolled out to APM instrumentation users
     if [ -z "$apm_instrumentation_enabled" ] && [ -z "$datadog_installer" ]; then
@@ -518,7 +519,7 @@ function _install_installer() {
     else
         return 0
     fi
-    $sudo_cmd DD_API_KEY="$apikey" DD_SITE="$site" DD_REMOTE_UPDATES="$remote_updates" DATADOG_TRACE_ID="$trace_id" DATADOG_PARENT_ID="$trace_id" datadog-boostrap bootstrap
+    $sudo_cmd sh -c "DD_API_KEY="$apikey" DD_SITE="$site" DD_REMOTE_UPDATES="$remote_updates" DATADOG_TRACE_ID="$trace_id" DATADOG_PARENT_ID="$trace_id" /usr/bin/datadog-bootstrap bootstrap"
     return $?
 }
 
@@ -527,7 +528,8 @@ function install_installer() {
     local sudo_cmd="$1"
     local os="$2"
     local distribution="$3"
-    local apm_instrumentation_enabled="$4"
+    local datadog_installer="$4"
+    local apm_instrumentation_enabled="$5"
 
     local trace_id
     local start_time
@@ -538,7 +540,7 @@ function install_installer() {
     trace_id=$(od -An -N8 -tu8 < /dev/urandom | tr -d ' ')
     start_time=$(date +%s%N)
 
-    (_install_installer "$sudo_cmd" "$os" "$distribution" "$apm_instrumentation_enabled" > /tmp/datadog-installer-stdout.log 2> /tmp/datadog-installer-stderr.log) || exit_status=$?
+    (_install_installer "$sudo_cmd" "$os" "$distribution" "$datadog_installer" "$apm_instrumentation_enabled" > /tmp/datadog-installer-stdout.log 2> /tmp/datadog-installer-stderr.log) || exit_status=$?
     exit_status=${exit_status:-0}
 
     install_stdout=$(cat /tmp/datadog-installer-stdout.log)
@@ -1661,6 +1663,11 @@ if [ -n "$docker_injection_enabled" ]; then
   $sudo_cmd dd-container-install --no-agent-restart
 fi
 
+# Install the installer
+if [ -n "$datadog_installer" ]; then
+  install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
+fi
+
 # Creating or overriding the install information
 function generate_install_id() {
   # Try generating a UUID based on /proc/sys/kernel/random/uuid
@@ -1775,10 +1782,6 @@ for current_service in "${services[@]}"; do
   eval "$restart_cmd"
 
   ERROR_MESSAGE=""
-
-  if [ -n "$datadog_installer" ]; then
-    install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_APM_INSTRUMENTATION_ENABLED" || true
-  fi
 
   # Metrics are submitted, echo some instructions and exit
   printf "\033[32m  Your ${nice_current_flavor} is running and functioning properly.\n\033[0m"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -505,11 +505,6 @@ function _install_installer() {
     local datadog_installer="$4"
     local apm_instrumentation_enabled="$5"
 
-    # The installer is currently only being rolled out to APM instrumentation users
-    if [ -z "$apm_instrumentation_enabled" ] && [ -z "$datadog_installer" ]; then
-        return 0
-    fi
-
     if [ "$os" == "Debian" ]; then
         echo -e "\033[34m\n* Installing the Datadog installer\n\033[0m"
         $sudo_cmd apt-get install -o Acquire::Retries="5" -y --force-yes "datadog-installer" || return $?
@@ -536,6 +531,11 @@ function install_installer() {
     local install_stdout
     local install_stderr
     local exit_status
+
+    # The installer is currently only being rolled out to APM instrumentation users
+    if [ -z "$apm_instrumentation_enabled" ] && [ -z "$datadog_installer" ]; then
+        return 0
+    fi
 
     trace_id=$(od -An -N8 -tu8 < /dev/urandom | tr -d ' ')
     start_time=$(date +%s%N)
@@ -1568,6 +1568,19 @@ function update_env(){
     $sudo_cmd sh -c "sed -i 's/^# env:.*/env: $dd_env/' $config_file"
   fi
 }
+function update_remote_updates(){
+  local sudo_cmd="$1"
+  local remote_updates="$2"
+  local config_file="$3"
+  if [ -n "$remote_updates" ]; then
+    printf "\033[34m\n* Adding your DD_REMOTE_UPDATES to the $nice_flavor configuration: $config_file\n\033[0m\n"
+    if ! $sudo_cmd grep -q "^remote_updates:" "$config_file"; then
+        $sudo_cmd sh -c "echo 'remote_updates: $remote_updates' >> $config_file"
+    else
+        $sudo_cmd sh -c "sed -i 's/^remote_updates:.*/remote_updates: $remote_updates/' $config_file"
+    fi
+  fi
+}
 function update_security_and_or_compliance(){
   local sudo_cmd="$1"
   local local_config_file="$2"
@@ -1632,6 +1645,17 @@ elif [ ! "$no_agent" ]; then
     update_hostname "$sudo_cmd" "$hostname" "$config_file"
     update_hosttags "$sudo_cmd" "$host_tags" "$config_file"
     update_env "$sudo_cmd" "$dd_env" "$config_file"
+    if [ -n "$remote_updates" ]; then
+      if [ -n "$fips_mode" ]; then
+        printf "\033[31mRemote updates are not supported in FIPS mode.\033[0m\n"
+      elif [ "$site" == "ddog-gov.com" ]; then
+        printf "\033[31mRemote updates are not supported with the Datadog Gov site.\033[0m\n"
+      elif [ -z "$datadog_installer" ]; then
+        printf "\033[31mRemote updates are not supported without the datadog installer.\033[0m\n"
+      else
+        update_remote_updates "$sudo_cmd" "$remote_updates" "$config_file"
+      fi
+    fi
   fi
   manage_security_and_system_probe_config "$sudo_cmd" "$security_agent_config_file" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
 fi
@@ -1661,11 +1685,6 @@ fi
 
 if [ -n "$docker_injection_enabled" ]; then
   $sudo_cmd dd-container-install --no-agent-restart
-fi
-
-# Install the installer
-if [ -n "$datadog_installer" ]; then
-  install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
 fi
 
 # Creating or overriding the install information
@@ -1804,5 +1823,10 @@ for current_service in "${services[@]}"; do
       sudo usermod -a -G docker dd-agent\033[0m\n\n"
   fi
 done
+
+# Install the installer
+if [ -n "$datadog_installer" ]; then
+  install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
+fi
 
 report_telemetry "$install_id" "$install_type" "$install_time"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -498,34 +498,28 @@ END
     fi
 }
 
-function configure_installer() {
-    local sudo_cmd="$1"
-    local trace_id="$2"
-    local apm_instrumentation_enabled="$3"
-
-    $sudo_cmd mkdir -p /etc/datadog-agent
-    $sudo_cmd bash -c "cat <<EOT > /etc/datadog-agent/datadog-installer.ini
-[features]
-apm_instrumentation=$apm_instrumentation_enabled
-
-[telemetry]
-trace_id=$trace_id
-parent_id=$trace_id
-priority=2
-EOT"
-}
-
 function _install_installer() {
     local sudo_cmd="$1"
     local os="$2"
     local distribution="$3"
     local apm_instrumentation_enabled="$4"
 
-    if [ "$os" == "Debian" ] && [ "$distribution" == "Debian" ] && [ -n "$apm_instrumentation_enabled" ]; then
-        echo -e "\033[34m\n* Installing the Datadog installer\n\033[0m"
-        configure_installer "$sudo_cmd" "$trace_id" "$apm_instrumentation_enabled"
-        $sudo_cmd apt-get install -o Acquire::Retries="5" -y --force-yes "datadog-installer"
+    # The installer is currently only being rolled out to APM instrumentation users
+    if [ -z "$apm_instrumentation_enabled" ] && [ -z "$datadog_installer" ]; then
+        return 0
     fi
+
+    if [ "$os" == "Debian" ]; then
+        echo -e "\033[34m\n* Installing the Datadog installer\n\033[0m"
+        $sudo_cmd apt-get install -o Acquire::Retries="5" -y --force-yes "datadog-installer" || return $?
+    elif [ "$os" == "RedHat" ]; then
+        echo -e "\033[34m\n* Installing the Datadog installer\n\033[0m"
+        $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "datadog-installer" || $sudo_cmd yum -y install $dnf_flag "datadog-installer" || return $?
+    else
+        return 0
+    fi
+    $sudo_cmd DD_API_KEY="$apikey" DD_SITE="$site" DATADOG_TRACE_ID="$trace_id" DATADOG_PARENT_ID="$trace_id" datadog-boostrap bootstrap
+    return $?
 }
 
 # Install the Datadog installer package

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1568,15 +1568,30 @@ function update_env(){
 }
 function update_remote_updates(){
   local sudo_cmd="$1"
-  local remote_updates="$2"
-  local config_file="$3"
-  if [ -n "$remote_updates" ]; then
-    printf "\033[34m\n* Adding your DD_REMOTE_UPDATES to the $nice_flavor configuration: $config_file\n\033[0m\n"
-    if ! $sudo_cmd grep -q "^remote_updates:" "$config_file"; then
-        $sudo_cmd sh -c "echo 'remote_updates: $remote_updates' >> $config_file"
-    else
-        $sudo_cmd sh -c "sed -i 's/^remote_updates:.*/remote_updates: $remote_updates/' $config_file"
-    fi
+  local datadog_installer="$2"
+  local remote_updates="$3"
+  local fips_mode="$4"
+  local site="$5"
+  local config_file="$6"
+
+  if [ -z "$remote_updates" ]; then
+    return 0
+  elif [ -n "$fips_mode" ]; then
+    printf "\033[31mRemote updates are not supported in FIPS mode.\033[0m\n"
+    return 0
+  elif [ "$site" == "ddog-gov.com" ]; then
+    printf "\033[31mRemote updates are not supported with the Datadog Gov site.\033[0m\n"
+    return 0
+  elif [ -z "$datadog_installer" ]; then
+    printf "\033[31mRemote updates are not supported without the datadog installer.\033[0m\n"
+    return 0
+  fi
+
+  printf "\033[34m\n* Adding your DD_REMOTE_UPDATES to the $nice_flavor configuration: $config_file\n\033[0m\n"
+  if ! $sudo_cmd grep -q "^remote_updates:" "$config_file"; then
+      $sudo_cmd sh -c "echo 'remote_updates: $remote_updates' >> $config_file"
+  else
+      $sudo_cmd sh -c "sed -i 's/^remote_updates:.*/remote_updates: $remote_updates/' $config_file"
   fi
 }
 function update_security_and_or_compliance(){
@@ -1643,17 +1658,7 @@ elif [ ! "$no_agent" ]; then
     update_hostname "$sudo_cmd" "$hostname" "$config_file"
     update_hosttags "$sudo_cmd" "$host_tags" "$config_file"
     update_env "$sudo_cmd" "$dd_env" "$config_file"
-    if [ -n "$remote_updates" ]; then
-      if [ -n "$fips_mode" ]; then
-        printf "\033[31mRemote updates are not supported in FIPS mode.\033[0m\n"
-      elif [ "$site" == "ddog-gov.com" ]; then
-        printf "\033[31mRemote updates are not supported with the Datadog Gov site.\033[0m\n"
-      elif [ -z "$datadog_installer" ]; then
-        printf "\033[31mRemote updates are not supported without the datadog installer.\033[0m\n"
-      else
-        update_remote_updates "$sudo_cmd" "$remote_updates" "$config_file"
-      fi
-    fi
+    update_remote_updates "$sudo_cmd" "$datadog_installer" "$remote_updates" "$fips_mode" "$site" "$config_file"
   fi
   manage_security_and_system_probe_config "$sudo_cmd" "$security_agent_config_file" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
 fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -502,8 +502,6 @@ function _install_installer() {
     local sudo_cmd="$1"
     local os="$2"
     local distribution="$3"
-    local datadog_installer="$4"
-    local apm_instrumentation_enabled="$5"
 
     if [ "$os" == "Debian" ]; then
         echo -e "\033[34m\n* Installing the Datadog installer\n\033[0m"
@@ -540,7 +538,7 @@ function install_installer() {
     trace_id=$(od -An -N8 -tu8 < /dev/urandom | tr -d ' ')
     start_time=$(date +%s%N)
 
-    (_install_installer "$sudo_cmd" "$os" "$distribution" "$datadog_installer" "$apm_instrumentation_enabled" > /tmp/datadog-installer-stdout.log 2> /tmp/datadog-installer-stderr.log) || exit_status=$?
+    (_install_installer "$sudo_cmd" "$os" "$distribution" > /tmp/datadog-installer-stdout.log 2> /tmp/datadog-installer-stderr.log) || exit_status=$?
     exit_status=${exit_status:-0}
 
     install_stdout=$(cat /tmp/datadog-installer-stdout.log)

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -519,7 +519,7 @@ function _install_installer() {
     else
         return 0
     fi
-    $sudo_cmd sh -c "DD_API_KEY="$apikey" DD_SITE="$site" DD_REMOTE_UPDATES="$remote_updates" DATADOG_TRACE_ID="$trace_id" DATADOG_PARENT_ID="$trace_id" /usr/bin/datadog-bootstrap bootstrap"
+    $sudo_cmd sh -c "DD_API_KEY=\"${apikey}\" DD_SITE=\"${site}\" DD_REMOTE_UPDATES=\"${remote_updates}\" DATADOG_TRACE_ID=\"${trace_id}\" DATADOG_PARENT_ID=\"${trace_id}\" /usr/bin/datadog-bootstrap bootstrap"
     return $?
 }
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -514,7 +514,7 @@ function _install_installer() {
         $sudo_cmd apt-get install -o Acquire::Retries="5" -y --force-yes "datadog-installer" || return $?
     elif [ "$os" == "RedHat" ]; then
         echo -e "\033[34m\n* Installing the Datadog installer\n\033[0m"
-        $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "datadog-installer" || $sudo_cmd yum -y install $dnf_flag "datadog-installer" || return $?
+        $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install "datadog-installer" || $sudo_cmd yum -y install "datadog-installer" || return $?
     else
         return 0
     fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -518,7 +518,7 @@ function _install_installer() {
     else
         return 0
     fi
-    $sudo_cmd DD_API_KEY="$apikey" DD_SITE="$site" DATADOG_TRACE_ID="$trace_id" DATADOG_PARENT_ID="$trace_id" datadog-boostrap bootstrap
+    $sudo_cmd DD_API_KEY="$apikey" DD_SITE="$site" DD_REMOTE_UPDATES="$remote_updates" DATADOG_TRACE_ID="$trace_id" DATADOG_PARENT_ID="$trace_id" datadog-boostrap bootstrap
     return $?
 }
 
@@ -620,6 +620,11 @@ fi
 datadog_installer=
 if [ -n "$DD_INSTALLER" ]; then
     datadog_installer=true
+fi
+
+remote_updates=
+if [ -n "$DD_REMOTE_UPDATES" ]; then
+    remote_updates=$DD_REMOTE_UPDATES
 fi
 
 ##


### PR DESCRIPTION
- add the new boostrap call
- remove the on-disk installer file
- add support for RPM
- setting DD_INSTALLER will always install, regardless of APM being enabled
- add `DD_REMOTE_UPDATES`