### PR TITLE
Revert "Revert "Install Old 2022 RPM GPG key only when needed for agent <= 7.35 (#174)" (#178)"

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -319,17 +319,6 @@ function get_relevant_rpm_gpg_keys() {
     echo "${gpgKeys[@]}"
 }
 
-function get_relevant_apt_gpg_keys() {
-    local minorVersion="$1"
-    shift
-    local gpgKeys=("$@")
-    # The last GPG key is only used on agent 7.35.X and lower
-    if [ -z "$minorVersion" ] || versionlt 35 "$minorVersion"; then
-        unset 'gpgKeys[${#gpgKeys[@]}-1]'
-    fi
-    echo "${gpgKeys[@]}"
-}
-
 # Emulate hashmap with simple switch case
 function getMapData() {
 
@@ -1226,7 +1215,7 @@ elif [ "$OS" == "Debian" ]; then
     # can read our keyring
     $sudo_cmd chmod a+r $apt_usr_share_keyring
 
-    for key in $(get_relevant_apt_gpg_keys "$agent_minor_version" "${APT_GPG_KEYS[@]}"); do
+    for key in "${APT_GPG_KEYS[@]}"; do
         $sudo_cmd curl -sSL --retry 5 -o "/tmp/${key}" "https://${keys_url}/${key}"
         $sudo_cmd cat "/tmp/${key}" | $sudo_cmd gpg --import --batch --no-default-keyring --keyring "$apt_usr_share_keyring"
     done

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -300,6 +300,36 @@ function remove_rpm_gpg_keys() {
     done
 }
 
+function versionlte() {
+    [  "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
+}
+
+function versionlt() {
+    ([ "$1" = "$2" ] && return 1) || versionlte "$1" "$2"
+}
+
+function get_relevant_rpm_gpg_keys() {
+    local minorVersion="$1"
+    shift
+    local gpgKeys=("$@")
+    # The last GPG key is only used on agent 7.35.X and lower
+    if [ -z "$minorVersion" ] || versionlt 35 "$minorVersion"; then
+        unset 'gpgKeys[${#gpgKeys[@]}-1]'
+    fi
+    echo "${gpgKeys[@]}"
+}
+
+function get_relevant_apt_gpg_keys() {
+    local minorVersion="$1"
+    shift
+    local gpgKeys=("$@")
+    # The last GPG key is only used on agent 7.35.X and lower
+    if [ -z "$minorVersion" ] || versionlt 35 "$minorVersion"; then
+        unset 'gpgKeys[${#gpgKeys[@]}-1]'
+    fi
+    echo "${gpgKeys[@]}"
+}
+
 # Emulate hashmap with simple switch case
 function getMapData() {
 
@@ -1080,7 +1110,7 @@ if [ "$OS" == "RedHat" ]; then
 
     gpgkeys=''
     separator='\n       '
-    for key_path in "${RPM_GPG_KEYS[@]}"; do
+    for key_path in $(get_relevant_rpm_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
       gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
     done
 
@@ -1196,7 +1226,7 @@ elif [ "$OS" == "Debian" ]; then
     # can read our keyring
     $sudo_cmd chmod a+r $apt_usr_share_keyring
 
-    for key in "${APT_GPG_KEYS[@]}"; do
+    for key in $(get_relevant_apt_gpg_keys "$agent_minor_version" "${APT_GPG_KEYS[@]}"); do
         $sudo_cmd curl -sSL --retry 5 -o "/tmp/${key}" "https://${keys_url}/${key}"
         $sudo_cmd cat "/tmp/${key}" | $sudo_cmd gpg --import --batch --no-default-keyring --keyring "$apt_usr_share_keyring"
     done
@@ -1340,12 +1370,12 @@ elif [ "$OS" == "SUSE" ]; then
   echo -e "\033[34m\n* Importing the Datadog GPG Keys\n\033[0m"
   if [ "$SUSE11" == "yes" ]; then
     # SUSE 11 special case
-    for key_path in "${RPM_GPG_KEYS[@]}"; do
+    for key_path in $(get_relevant_rpm_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
       $sudo_cmd curl -sSL --retry 5 -o "/tmp/${key_path}" "https://${keys_url}/${key_path}"
       $sudo_cmd rpm --import "/tmp/${key_path}"
     done
   else
-    for key_path in "${RPM_GPG_KEYS[@]}"; do
+    for key_path in $(get_relevant_rpm_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
       $sudo_cmd rpm --import "https://${keys_url}/${key_path}"
     done
   fi
@@ -1359,7 +1389,7 @@ elif [ "$OS" == "SUSE" ]; then
   if [ -n "$SUSE_VER" ] && [ "$SUSE_VER" -ge 15 ] && [ "$SUSE_VER" -ne 42 ]; then
     gpgkeys=''
     separator='\n       '
-    for key_path in "${RPM_GPG_KEYS[@]}"; do
+    for key_path in $(get_relevant_rpm_gpg_keys "$agent_minor_version" "${RPM_GPG_KEYS[@]}"); do
       gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
     done
   fi

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -146,7 +146,7 @@ func (s *installTestSuite) assertGPGKeys(allKeysNeeded bool) {
 		output, err := vm.ExecuteWithError("apt-key --keyring /usr/share/keyrings/datadog-archive-keyring.gpg list 2>/dev/null | grep -oE [0-9A-Z\\ ]{9}$")
 		t.Log(output)
 		assert.NoError(t, err)
-		// assert.Equal(t, allKeysNeeded, strings.Contains(output, "382E 94DE")) TODO: datadog-signing-keys for now is installing expired key on package install
+		assert.True(t, strings.Contains(output, "382E 94DE"))
 		assert.True(t, strings.Contains(output, "F14F 620E"))
 		assert.True(t, strings.Contains(output, "C096 2C7D"))
 	} else {


### PR DESCRIPTION
Revert #178 which was reverting #174 additionally apt gpg keys is going to stay reverted since the `datadog-signing-keys` package is conflicting with the relevant gpg keys selection