### PR TITLE
(fleet) enable installer on us3 for APM single step beta customers

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1828,7 +1828,7 @@ for current_service in "${services[@]}"; do
 done
 
 # Install the installer
-if [ -n "$datadog_installer" ]; then
+if [ -n "$datadog_installer" ] || [ "$site" == "us3.datadoghq.com" ]; then
   install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
 fi
 


### PR DESCRIPTION
First step of the migration to the installer for [APM single step](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=linuxhostorvm) beta customers.

The installer will gradually replace the installation of deb/rpm packages for APM's injector and libraries.