### PR TITLE
Revert "(fleet) enable installer on us3 for APM single step beta customers"

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1828,7 +1828,7 @@ for current_service in "${services[@]}"; do
 done
 
 # Install the installer
-if [ -n "$datadog_installer" ] || [ "$site" == "us3.datadoghq.com" ]; then
+if [ -n "$datadog_installer" ]; then
   install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
 fi
 


### PR DESCRIPTION
Reverts DataDog/agent-linux-install-script#186. (In case something goes wrong).