### PR TITLE
(fleet) scope to debian

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -530,6 +530,11 @@ function install_installer() {
     local install_stderr
     local exit_status
 
+    # The installer is currently only being rolled out to debian
+    if [ "$os" != "Debian" ] && [ -z "$datadog_installer" ]; then
+        return 0
+    fi
+
     # The installer is currently only being rolled out to APM instrumentation users
     if [ -z "$apm_instrumentation_enabled" ] && [ -z "$datadog_installer" ]; then
         return 0


### PR DESCRIPTION
Reduce the deployment of the installer in https://github.com/DataDog/agent-linux-install-script/pull/186 to only debian/ubuntu  users.