### PR TITLE
[E2E] Disable extraintegration check on pinned version agent

### DIFF
--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -49,13 +49,14 @@ func (s *installTestSuite) TestInstall() {
 }
 
 func (s *installTestSuite) TestInstallMinorVersionPin() {
+	vm := s.Env().VM
+
 	// Installation
 	s.InstallAgent(7, "DD_AGENT_MINOR_VERSION=42.0", "Install Agent 7 pinned to 7.42.0")
 
 	s.assertPinnedInstallScript("7.42.0")
 
-	// Disabled : integrations expired since First May 2024 for 7.42.0
-	//s.addExtraIntegration()
+	_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", s.getLatestEmbeddedPythonPath(s.baseName)))
 
 	s.uninstall()
 

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -56,7 +56,9 @@ func (s *installTestSuite) TestInstallMinorVersionPin() {
 
 	s.assertPinnedInstallScript("7.42.0")
 
-	_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", s.getLatestEmbeddedPythonPath(s.baseName)))
+	if flavor == "datadog-agent" {
+		_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", s.getLatestEmbeddedPythonPath(s.baseName)))
+	}
 
 	s.uninstall()
 

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -54,7 +54,8 @@ func (s *installTestSuite) TestInstallMinorVersionPin() {
 
 	s.assertPinnedInstallScript("7.42.0")
 
-	s.addExtraIntegration()
+	// Disabled : integrations expired since First May 2024 for 7.42.0
+	//s.addExtraIntegration()
 
 	s.uninstall()
 

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -49,8 +49,6 @@ func (s *installTestSuite) TestInstall() {
 }
 
 func (s *installTestSuite) TestInstallMinorVersionPin() {
-	vm := s.Env().VM
-
 	// Installation
 	s.InstallAgent(7, "DD_AGENT_MINOR_VERSION=42.0", "Install Agent 7 pinned to 7.42.0")
 

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -56,13 +56,7 @@ func (s *installTestSuite) TestInstallMinorVersionPin() {
 
 	s.assertPinnedInstallScript("7.42.0")
 
-	if flavor == "datadog-agent" {
-		_ = vm.Execute(fmt.Sprintf("sudo -u dd-agent -- touch %s/site-packages/testfile", s.getLatestEmbeddedPythonPath(s.baseName)))
-	}
-
 	s.uninstall()
-
-	s.assertUninstall()
 
 	s.purge()
 


### PR DESCRIPTION
integrations metadata expired since First May 2024 for 7.42.0 and needs to be disabled

Left as comment for now, might replace the test later with another test with `--unsafe-disable-verification` since we're pinning to the very first version of the package