### PR TITLE
[PROF-9675] Support for SSI Profiling allow list config

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1616,6 +1616,18 @@ function manage_client_libraries_security_config(){
     $sudo_cmd sed -i -n -e '/^DD_APPSEC_SCA_ENABLED=/!p' -e "\$aDD_APPSEC_SCA_ENABLED=$sca_enable" "$etc_environment"
   fi
 }
+function manage_client_libraries_profiling_config(){
+  local sudo_cmd="$1"
+  local etc_environment="$2"
+  local profiling_enable="$3"
+  local profiling_allowlist="$4"
+  if [ -n "$profiling_enable" ]; then
+    $sudo_cmd sed -i -n -e '/^DD_PROFILING_ENABLED=/!p' -e "\$aDD_PROFILING_ENABLED=$profiling_enable" "$etc_environment"
+  fi
+  if [ -n "$profiling_allowlist" ]; then
+    $sudo_cmd sed -i -n -e '/^DD_PROFILING_ALLOWLIST=/!p' -e "\$aDD_PROFILING_ALLOWLIST=$profiling_allowlist" "$etc_environment"
+  fi
+}
 # "Main" configuration update
 if [ -e "$config_file" ] && [ -z "$upgrade" ]; then
   printf "\033[34m\n* Keeping old $config_file configuration file\n\033[0m\n"
@@ -1636,6 +1648,7 @@ elif [ ! "$no_agent" ]; then
 fi
 
 manage_client_libraries_security_config "$sudo_cmd" "/etc/environment" "$DD_APPSEC_ENABLED" "$DD_IAST_ENABLED" "$DD_APPSEC_SCA_ENABLED"
+manage_client_libraries_profiling_config "$sudo_cmd" "/etc/environment" "$DD_PROFILING_ENABLED" "$DD_PROFILING_ALLOWLIST"
 
 if [ ! "$no_agent" ]; then
   $sudo_cmd chown dd-agent:dd-agent "$config_file"


### PR DESCRIPTION
Add support for a simplified SSI profiling setup where service names are included in a CSV env during agent installation.

When a process launch gets intercepted by the Datadog SSI preload launcher, if the resolved service name of that process aligns with one in the profiling allowlist, then `DD_PROFILING_ENABLED=true` gets injected into the ENV vars of that service.

The companion PR in the SSI preload launcher is: TODO