### PR TITLE
(fleet) filter out packages installed by the installer

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -555,6 +555,39 @@ function install_installer() {
     return $exit_status
 }
 
+is_installed_by_installer() {
+    if command -v datadog-installer >/dev/null 2>&1; then
+        # If 'installer' is available, use it to check if the package is installed
+        installer is-installed "$1"
+        local status=$?
+        if [ $status -eq 0 ]; then
+            return 0  # Package is installed
+        elif [ $status -eq 10 ]; then
+            return 1  # Package is not installed
+        else
+            return $status  # Some other error occurred
+        fi
+    else
+        return 1
+    fi
+}
+
+filter_packages_installed_by_installer() {
+    local -n arr=$1  # Using nameref to refer to the array passed by name
+    local not_installed_packages=()
+
+    for package in "${arr[@]}"; do
+        if ! is_installed_by_installer "$package"; then
+            not_installed_packages+=("$package")
+        else
+            echo -e "\033[34m\n* Skipping installation of $package as it is already installed by the installer\n\033[0m"
+        fi
+    done
+
+    # Copy the filtered array back to the original array
+    arr=("${not_installed_packages[@]}")
+}
+
 echo -e "\033[34m\n* Datadog INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER install script v${install_script_version}\n\033[0m"
 
 ##
@@ -1029,6 +1062,9 @@ else
     sudo_cmd='sudo'
 fi
 
+# Install the installer
+install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
+
 ##
 # INSTALL THE NECESSARY PACKAGE SOURCES
 ##
@@ -1143,6 +1179,7 @@ if [ "$OS" == "RedHat" ]; then
     # packages can be empty if no_agent is set
     if [ ${#packages[@]} -ne 0 ]; then
       echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
+      filter_packages_installed_by_installer packages
 
       # yum has a default retry of 10 https://github.com/Distrotech/yum/blob/f4e54aeed297158c563828aa3ebb93d0c8ce7e38/docs/yum.conf.5#L364-L366
       $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
@@ -1286,6 +1323,7 @@ If the cause is unclear, please contact Datadog support.
     fi
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
+    filter_packages_installed_by_installer packages
 
     $sudo_cmd apt-get install -o Acquire::Retries="5" -y --force-yes "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
 
@@ -1441,6 +1479,7 @@ elif [ "$OS" == "SUSE" ]; then
 
   if [ ${#packages[@]} -ne 0 ]; then
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
+    filter_packages_installed_by_installer packages
     # Not yet retry mechanism in zypper, see https://github.com/openSUSE/zypper/issues/420
     if [ -z "$sudo_cmd" ]; then
       ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:
@@ -1690,12 +1729,14 @@ if [ -n "$system_probe_ensure_config" ]; then
 fi
 
 # run apm injection scripts
-if [ -n "$host_injection_enabled" ]; then
-  $sudo_cmd dd-host-install --no-agent-restart ${no_config_change}
-fi
+if ! is_installed_by_installer "datadog-apm-inject"; then
+  if [ -n "$host_injection_enabled" ]; then
+    $sudo_cmd dd-host-install --no-agent-restart ${no_config_change}
+  fi
 
-if [ -n "$docker_injection_enabled" ]; then
-  $sudo_cmd dd-container-install --no-agent-restart
+  if [ -n "$docker_injection_enabled" ]; then
+    $sudo_cmd dd-container-install --no-agent-restart
+  fi
 fi
 
 # Creating or overriding the install information
@@ -1834,8 +1875,5 @@ for current_service in "${services[@]}"; do
       sudo usermod -a -G docker dd-agent\033[0m\n\n"
   fi
 done
-
-# Install the installer
-install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
 
 report_telemetry "$install_id" "$install_type" "$install_time"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1063,9 +1063,6 @@ else
     sudo_cmd='sudo'
 fi
 
-# Install the installer
-install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
-
 ##
 # INSTALL THE NECESSARY PACKAGE SOURCES
 ##
@@ -1176,6 +1173,9 @@ if [ "$OS" == "RedHat" ]; then
         fi
       done
     fi
+
+    # Install the installer
+    install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
 
     # packages can be empty if no_agent is set
     if [ ${#packages[@]} -ne 0 ]; then
@@ -1322,6 +1322,9 @@ If the cause is unclear, please contact Datadog support.
         fi
       done
     fi
+
+    # Install the installer
+    install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
 
     filter_packages_installed_by_installer "$sudo_cmd" packages
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
@@ -1477,6 +1480,9 @@ elif [ "$OS" == "SUSE" ]; then
     report_telemetry
     exit 1;
   fi
+
+  # Install the installer
+  install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
 
   if [ ${#packages[@]} -ne 0 ]; then
     filter_packages_installed_by_installer "$sudo_cmd" packages

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1748,7 +1748,7 @@ if [ -n "$system_probe_ensure_config" ]; then
 fi
 
 # run apm injection scripts
-if ! is_installed_by_installer "datadog-apm-inject"; then
+if ! is_installed_by_installer "$sudo_cmd" "datadog-apm-inject"; then
   if [ -n "$host_injection_enabled" ]; then
     $sudo_cmd dd-host-install --no-agent-restart ${no_config_change}
   fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -370,7 +370,7 @@ function report_installer_telemetry() {
     local install_stdout="$6"
     local install_stderr="$7"
     local packages_to_install="$8"
-    local pacakges_to_install_after_installer="$9"
+    local packages_to_install_after_installer="$9"
 
     install_stdout=$(json_escape "$install_stdout")
     install_stderr=$(json_escape "$install_stderr")
@@ -435,7 +435,7 @@ function report_installer_telemetry() {
                         "error.message": "${install_stderr}",
                         "version": "${install_script_version}",
                         "packages_to_install": "$(json_escape "${packages_to_install}")",
-                        "packages_to_install_after_installer": "$(json_escape "${pacakges_to_install_after_installer}")"
+                        "packages_to_install_after_installer": "$(json_escape "${packages_to_install_after_installer}")"
                     },
                     "metrics": {
                         "_trace_root": 1,
@@ -589,7 +589,7 @@ function install_installer() {
     exit_status=${exit_status:-0}
 
     local packages_to_install
-    local pacakges_to_install_after_installer
+    local packages_to_install_after_installer
 
     packages_to_install=("${!pkg_array_name}")
     filter_packages_installed_by_installer "$sudo_cmd" "$pkg_array_name"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -573,10 +573,10 @@ is_installed_by_installer() {
 }
 
 filter_packages_installed_by_installer() {
-    local -n arr=$1  # Using nameref to refer to the array passed by name
-    local not_installed_packages=()
+    local pkg_array_name=$1
+    local -a not_installed_packages=()  # Temporary array for not installed packages
 
-    for package in "${arr[@]}"; do
+    for package in "${!pkg_array_name}"; do
         if ! is_installed_by_installer "$package"; then
             not_installed_packages+=("$package")
         else
@@ -585,7 +585,7 @@ filter_packages_installed_by_installer() {
     done
 
     # Copy the filtered array back to the original array
-    arr=("${not_installed_packages[@]}")
+    eval "$pkg_array_name=(\"\${not_installed_packages[@]}\")"
 }
 
 echo -e "\033[34m\n* Datadog INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER install script v${install_script_version}\n\033[0m"
@@ -1179,7 +1179,7 @@ if [ "$OS" == "RedHat" ]; then
     # packages can be empty if no_agent is set
     if [ ${#packages[@]} -ne 0 ]; then
       echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
-      filter_packages_installed_by_installer packages
+      filter_packages_installed_by_installer "packages"
 
       # yum has a default retry of 10 https://github.com/Distrotech/yum/blob/f4e54aeed297158c563828aa3ebb93d0c8ce7e38/docs/yum.conf.5#L364-L366
       $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
@@ -1323,7 +1323,7 @@ If the cause is unclear, please contact Datadog support.
     fi
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
-    filter_packages_installed_by_installer packages
+    filter_packages_installed_by_installer "packages"
 
     $sudo_cmd apt-get install -o Acquire::Retries="5" -y --force-yes "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
 
@@ -1479,7 +1479,7 @@ elif [ "$OS" == "SUSE" ]; then
 
   if [ ${#packages[@]} -ne 0 ]; then
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
-    filter_packages_installed_by_installer packages
+    filter_packages_installed_by_installer "packages"
     # Not yet retry mechanism in zypper, see https://github.com/openSUSE/zypper/issues/420
     if [ -z "$sudo_cmd" ]; then
       ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -558,7 +558,7 @@ function install_installer() {
 is_installed_by_installer() {
     if command -v datadog-installer >/dev/null 2>&1; then
         # If 'installer' is available, use it to check if the package is installed
-        installer is-installed "$1"
+        datadog-installer is-installed "$1"
         local status=$?
         if [ $status -eq 0 ]; then
             return 0  # Package is installed

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1178,8 +1178,8 @@ if [ "$OS" == "RedHat" ]; then
 
     # packages can be empty if no_agent is set
     if [ ${#packages[@]} -ne 0 ]; then
-      echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
       filter_packages_installed_by_installer "packages"
+      echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
       # yum has a default retry of 10 https://github.com/Distrotech/yum/blob/f4e54aeed297158c563828aa3ebb93d0c8ce7e38/docs/yum.conf.5#L364-L366
       $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd yum -y install $dnf_flag "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
@@ -1322,8 +1322,8 @@ If the cause is unclear, please contact Datadog support.
       done
     fi
 
-    echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
     filter_packages_installed_by_installer "packages"
+    echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
     $sudo_cmd apt-get install -o Acquire::Retries="5" -y --force-yes "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
 
@@ -1478,8 +1478,8 @@ elif [ "$OS" == "SUSE" ]; then
   fi
 
   if [ ${#packages[@]} -ne 0 ]; then
-    echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
     filter_packages_installed_by_installer "packages"
+    echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
     # Not yet retry mechanism in zypper, see https://github.com/openSUSE/zypper/issues/420
     if [ -z "$sudo_cmd" ]; then
       ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2) ||:

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -555,7 +555,7 @@ function install_installer() {
     return $exit_status
 }
 
-is_installed_by_installer() {
+function is_installed_by_installer() {
     if command -v datadog-installer >/dev/null 2>&1; then
         datadog-installer is-installed "$1"
         local status=$?
@@ -571,7 +571,7 @@ is_installed_by_installer() {
     fi
 }
 
-filter_packages_installed_by_installer() {
+function filter_packages_installed_by_installer() {
     local pkg_array_name=$1
     local -a not_installed_packages=()  # Temporary array for not installed packages
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -597,7 +597,7 @@ function install_installer() {
 
     install_stdout=$(cat /tmp/datadog-installer-stdout.log)
     install_stderr=$(cat /tmp/datadog-installer-stderr.log)
-    (report_installer_telemetry "$trace_id" "$os" "$distribution" "$start_time" "$exit_status" "$install_stdout" "$install_stderr") || true
+    (report_installer_telemetry "$trace_id" "$os" "$distribution" "$start_time" "$exit_status" "$install_stdout" "$install_stderr" "${packages_to_install[*]}" "${packages_to_install_after_installer[*]}") || true
     return $exit_status
 }
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -369,6 +369,8 @@ function report_installer_telemetry() {
     local exit_code="$5"
     local install_stdout="$6"
     local install_stderr="$7"
+    local packages_to_install="$8"
+    local pacakges_to_install_after_installer="$9"
 
     install_stdout=$(json_escape "$install_stdout")
     install_stderr=$(json_escape "$install_stderr")
@@ -431,7 +433,9 @@ function report_installer_telemetry() {
                         "language": "shell",
                         "exit_code": ${exit_code},
                         "error.message": "${install_stderr}",
-                        "version": "${install_script_version}"
+                        "version": "${install_script_version}",
+                        "packages_to_install": "$(json_escape "${packages_to_install}")",
+                        "packages_to_install_after_installer": "$(json_escape "${pacakges_to_install_after_installer}")"
                     },
                     "metrics": {
                         "_trace_root": 1,
@@ -519,42 +523,6 @@ function _install_installer() {
     return $?
 }
 
-# Install the Datadog installer package
-function install_installer() {
-    local sudo_cmd="$1"
-    local os="$2"
-    local distribution="$3"
-    local datadog_installer="$4"
-    local apm_instrumentation_enabled="$5"
-
-    local trace_id
-    local start_time
-    local install_stdout
-    local install_stderr
-    local exit_status
-
-    # The installer is currently only being rolled out to APM instrumentation users
-    if [ -z "$apm_instrumentation_enabled" ] && [ -z "$datadog_installer" ]; then
-        return 0
-    fi
-
-    # The installer is only supported on Debian and RedHat based distributions for now
-    if [ "$os" != "Debian" ] && [ "$os" != "RedHat" ]; then
-        return 0
-    fi
-
-    trace_id=$(od -An -N8 -tu8 < /dev/urandom | tr -d ' ')
-    start_time=$(date +%s%N)
-
-    (_install_installer "$sudo_cmd" "$os" "$distribution" > /tmp/datadog-installer-stdout.log 2> /tmp/datadog-installer-stderr.log) || exit_status=$?
-    exit_status=${exit_status:-0}
-
-    install_stdout=$(cat /tmp/datadog-installer-stdout.log)
-    install_stderr=$(cat /tmp/datadog-installer-stderr.log)
-    (report_installer_telemetry "$trace_id" "$os" "$distribution" "$start_time" "$exit_status" "$install_stdout" "$install_stderr") || true
-    return $exit_status
-}
-
 function is_installed_by_installer() {
     local sudo_cmd="$1"
     if command -v datadog-installer >/dev/null 2>&1; then
@@ -587,6 +555,50 @@ function filter_packages_installed_by_installer() {
 
     # Copy the filtered array back to the original array
     eval "$pkg_array_name=(\"\${not_installed_packages[@]}\")"
+}
+
+# Install the Datadog installer package
+function install_installer() {
+    local sudo_cmd="$1"
+    local os="$2"
+    local distribution="$3"
+    local datadog_installer="$4"
+    local apm_instrumentation_enabled="$5"
+    local pkg_array_name="$6"
+
+    local trace_id
+    local start_time
+    local install_stdout
+    local install_stderr
+    local exit_status
+
+    # The installer is currently only being rolled out to APM instrumentation users
+    if [ -z "$apm_instrumentation_enabled" ] && [ -z "$datadog_installer" ]; then
+        return 0
+    fi
+
+    # The installer is only supported on Debian and RedHat based distributions for now
+    if [ "$os" != "Debian" ] && [ "$os" != "RedHat" ]; then
+        return 0
+    fi
+
+    trace_id=$(od -An -N8 -tu8 < /dev/urandom | tr -d ' ')
+    start_time=$(date +%s%N)
+
+    (_install_installer "$sudo_cmd" "$os" "$distribution" > /tmp/datadog-installer-stdout.log 2> /tmp/datadog-installer-stderr.log) || exit_status=$?
+    exit_status=${exit_status:-0}
+
+    local packages_to_install
+    local pacakges_to_install_after_installer
+
+    packages_to_install=("${!pkg_array_name}")
+    filter_packages_installed_by_installer "$sudo_cmd" "$pkg_array_name"
+    packages_to_install_after_installer=("${!pkg_array_name}")
+
+    install_stdout=$(cat /tmp/datadog-installer-stdout.log)
+    install_stderr=$(cat /tmp/datadog-installer-stderr.log)
+    (report_installer_telemetry "$trace_id" "$os" "$distribution" "$start_time" "$exit_status" "$install_stdout" "$install_stderr") || true
+    return $exit_status
 }
 
 echo -e "\033[34m\n* Datadog INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER install script v${install_script_version}\n\033[0m"
@@ -1175,11 +1187,11 @@ if [ "$OS" == "RedHat" ]; then
     fi
 
     # Install the installer
-    install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
+    # Note: this function will remove installed packages from the "packages" array
+    install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" "packages" || true
 
     # packages can be empty if no_agent is set
     if [ ${#packages[@]} -ne 0 ]; then
-      filter_packages_installed_by_installer "$sudo_cmd" packages
       echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
       # yum has a default retry of 10 https://github.com/Distrotech/yum/blob/f4e54aeed297158c563828aa3ebb93d0c8ce7e38/docs/yum.conf.5#L364-L366
@@ -1324,9 +1336,9 @@ If the cause is unclear, please contact Datadog support.
     fi
 
     # Install the installer
-    install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
+    # Note: this function will remove installed packages from the "packages" array
+    install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" "packages" || true
 
-    filter_packages_installed_by_installer "$sudo_cmd" packages
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
     $sudo_cmd apt-get install -o Acquire::Retries="5" -y --force-yes "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
@@ -1481,11 +1493,11 @@ elif [ "$OS" == "SUSE" ]; then
     exit 1;
   fi
 
-  # Install the installer
-  install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" || true
+    # Install the installer
+    # Note: this function will remove installed packages from the "packages" array
+    install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_APM_INSTRUMENTATION_ENABLED" "packages" || true
 
   if [ ${#packages[@]} -ne 0 ]; then
-    filter_packages_installed_by_installer "$sudo_cmd" packages
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
     # Not yet retry mechanism in zypper, see https://github.com/openSUSE/zypper/issues/420
     if [ -z "$sudo_cmd" ]; then

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -556,8 +556,9 @@ function install_installer() {
 }
 
 function is_installed_by_installer() {
+    local sudo_cmd="$1"
     if command -v datadog-installer >/dev/null 2>&1; then
-        datadog-installer is-installed "$1"
+        $sudo_cmd datadog-installer is-installed "$2"
         local status=$?
         if [ $status -eq 0 ]; then
             return 0
@@ -572,11 +573,12 @@ function is_installed_by_installer() {
 }
 
 function filter_packages_installed_by_installer() {
-    local pkg_array_name=$1
+    local sudo_cmd="$1"
+    local pkg_array_name=$2
     local -a not_installed_packages=()  # Temporary array for not installed packages
 
     for package in $(eval echo "\${${pkg_array_name}[@]}"); do
-        if ! is_installed_by_installer "$package"; then
+        if ! is_installed_by_installer "$sudo_cmd" "$package"; then
             not_installed_packages+=("$package")
         else
             echo -e "\033[34m\n* Skipping installation of $package as it is already installed by the installer\n\033[0m"
@@ -1177,7 +1179,7 @@ if [ "$OS" == "RedHat" ]; then
 
     # packages can be empty if no_agent is set
     if [ ${#packages[@]} -ne 0 ]; then
-      filter_packages_installed_by_installer "packages"
+      filter_packages_installed_by_installer "$sudo_cmd" packages
       echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
       # yum has a default retry of 10 https://github.com/Distrotech/yum/blob/f4e54aeed297158c563828aa3ebb93d0c8ce7e38/docs/yum.conf.5#L364-L366
@@ -1321,7 +1323,7 @@ If the cause is unclear, please contact Datadog support.
       done
     fi
 
-    filter_packages_installed_by_installer "packages"
+    filter_packages_installed_by_installer "$sudo_cmd" packages
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
     $sudo_cmd apt-get install -o Acquire::Retries="5" -y --force-yes "${packages[@]}" 2> >(tee /tmp/ddog_install_error_msg >&2)
@@ -1477,7 +1479,7 @@ elif [ "$OS" == "SUSE" ]; then
   fi
 
   if [ ${#packages[@]} -ne 0 ]; then
-    filter_packages_installed_by_installer "packages"
+    filter_packages_installed_by_installer "$sudo_cmd" packages
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
     # Not yet retry mechanism in zypper, see https://github.com/openSUSE/zypper/issues/420
     if [ -z "$sudo_cmd" ]; then

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -557,15 +557,14 @@ function install_installer() {
 
 is_installed_by_installer() {
     if command -v datadog-installer >/dev/null 2>&1; then
-        # If 'installer' is available, use it to check if the package is installed
         datadog-installer is-installed "$1"
         local status=$?
         if [ $status -eq 0 ]; then
-            return 0  # Package is installed
-        elif [ $status -eq 10 ]; then
-            return 1  # Package is not installed
+            return 0
+        elif [ $status -eq 10 ]; then # 10 means the package is not installed
+            return 1
         else
-            return $status  # Some other error occurred
+            return $status
         fi
     else
         return 1
@@ -576,7 +575,7 @@ filter_packages_installed_by_installer() {
     local pkg_array_name=$1
     local -a not_installed_packages=()  # Temporary array for not installed packages
 
-    for package in "${!pkg_array_name}"; do
+    for package in $(eval echo "\${${pkg_array_name}[@]}"); do
         if ! is_installed_by_installer "$package"; then
             not_installed_packages+=("$package")
         else

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -58,7 +58,7 @@ const isInstalledScript = `#!/bin/bash
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
 	vm := s.Env().VM
-	vm.Execute("echo '" + isInstalledScript + "' | sudo -E tee /usr/bin/datadog-installer && sudo chmod +x /usr/bin/datadog-installer")
+	vm.Execute("echo '" + isInstalledScript + "' > /tmp/datadog-installer && sudo mv /tmp/datadog-installer /usr/bin/datadog-installer && sudo chmod +x /usr/bin/datadog-installer")
 	cmd := fmt.Sprintf("DD_APM_INSTRUMENTATION_ENABLED=host DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=%s DD_SITE=\"datadoghq.com\" DD_REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(output)

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -60,8 +60,10 @@ func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalle
 	vm := s.Env().VM
 	vm.Execute("echo 'export PATH=/usr/local/bin:$PATH' | sudo tee -a /etc/profile")
 	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")
+	t.Log(vm.Execute("which datadog-installer"))
 	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
+	t.Log(vm.Execute("which datadog-installer"))
 	t.Log(output)
 	defer s.purge()
 

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -58,8 +58,8 @@ const isInstalledScript = `#!/bin/bash
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
 	vm := s.Env().VM
-	vm.Execute("echo 'export PATH=/:$PATH' >> /etc/profile")
-	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /datadog-installer && sudo chmod +x /datadog-installer")
+	vm.Execute("echo 'export PATH=/usr/local/bin:$PATH' >> /etc/profile")
+	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")
 	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(output)

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -61,9 +61,11 @@ func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalle
 	vm.Execute("echo 'export PATH=/usr/local/bin:$PATH' | sudo tee -a /etc/profile")
 	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")
 	t.Log(vm.Execute("which datadog-installer"))
+	t.Log(vm.Execute("sudo which datadog-installer"))
 	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(vm.Execute("which datadog-installer"))
+	t.Log(vm.Execute("sudo which datadog-installer"))
 	t.Log(output)
 	defer s.purge()
 

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -55,11 +55,11 @@ func (s *installUpdaterTestSuite) TestInstallUpdater() {
 const isInstalledScript = `#!/bin/bash
 [[ "$1" == "is-installed" ]] && { [[ "$2" == "datadog-apm-inject" || "$2" == "datadog-apm-library-python" ]] && exit 0 || exit 1; } || { echo "Unsupported command"; exit 2; }`
 
-
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
 	vm := s.Env().VM
-	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")
+	vm.Execute("echo 'export PATH=/:$PATH' >> /etc/profile")
+	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /datadog-installer && sudo chmod +x /datadog-installer")
 	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(output)

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -60,7 +60,7 @@ func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalle
 	vm := s.Env().VM
 	vm.Execute("echo 'export PATH=/usr/local/bin:$PATH' | sudo tee -a /etc/profile")
 	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")
-	_ = vm.ExecuteWithError("echo '" + isInstalledScript + "' | sudo tee /sbin/datadog-installer && sudo chmod +x /sbin/datadog-installer")
+	_, _ = vm.ExecuteWithError("echo '" + isInstalledScript + "' | sudo tee /sbin/datadog-installer && sudo chmod +x /sbin/datadog-installer")
 	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(output)

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -59,7 +59,7 @@ const isInstalledScript = `#!/bin/bash
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
 	vm := s.Env().VM
-	vm.Execute("echo '" + isInstalledScript + "' > /datadog-installer && chmod +x /datadog-installer")
+	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /datadog-installer && sudo chmod +x /datadog-installer")
 	cmd := fmt.Sprintf("PATH=/:$PATH DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=%s DD_SITE=\"datadoghq.com\" DD_REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(output)

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -60,12 +60,9 @@ func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalle
 	vm := s.Env().VM
 	vm.Execute("echo 'export PATH=/usr/local/bin:$PATH' | sudo tee -a /etc/profile")
 	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")
-	t.Log(vm.Execute("which datadog-installer"))
-	t.Log(vm.Execute("sudo which datadog-installer"))
+	_ = vm.ExecuteWithError("echo '" + isInstalledScript + "' | sudo tee /sbin/datadog-installer && sudo chmod +x /sbin/datadog-installer")
 	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
-	t.Log(vm.Execute("which datadog-installer"))
-	t.Log(vm.Execute("sudo which datadog-installer"))
 	t.Log(output)
 	defer s.purge()
 

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -37,7 +37,7 @@ func TestInstallUpdaterSuite(t *testing.T) {
 func (s *installUpdaterTestSuite) TestInstallUpdater() {
 	t := s.T()
 	vm := s.Env().VM
-	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_APM_INSTRUMENTATION_LANGUAGES=\" \" DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=%s DD_SITE=\"datadoghq.com\" DD_REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
+	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_APM_INSTRUMENTATION_LANGUAGES=\" \" DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(output)
 	defer s.purge()
@@ -59,8 +59,8 @@ const isInstalledScript = `#!/bin/bash
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
 	vm := s.Env().VM
-	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /datadog-installer && sudo chmod +x /datadog-installer")
-	cmd := fmt.Sprintf("PATH=/:$PATH DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=%s DD_SITE=\"datadoghq.com\" DD_REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
+	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")
+	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(output)
 	defer s.purge()

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -58,8 +58,7 @@ const isInstalledScript = `#!/bin/bash
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
 	vm := s.Env().VM
-	t.Log(vm.Execute("env"))
-	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/bin/datadog-installer && sudo chmod +x /usr/bin/datadog-installer")
+	vm.Execute("echo '" + isInstalledScript + "' | sudo -E tee /usr/bin/datadog-installer && sudo chmod +x /usr/bin/datadog-installer")
 	cmd := fmt.Sprintf("DD_APM_INSTRUMENTATION_ENABLED=host DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=%s DD_SITE=\"datadoghq.com\" DD_REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(output)

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -58,7 +58,7 @@ const isInstalledScript = `#!/bin/bash
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
 	vm := s.Env().VM
-	vm.Execute("echo 'export PATH=/usr/local/bin:$PATH' >> /etc/profile")
+	vm.Execute("echo 'export PATH=/usr/local/bin:$PATH' | sudo tee -a /etc/profile")
 	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")
 	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -58,6 +58,7 @@ const isInstalledScript = `#!/bin/bash
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
 	vm := s.Env().VM
+	t.Log(vm.Execute("env"))
 	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/bin/datadog-installer && sudo chmod +x /usr/bin/datadog-installer")
 	cmd := fmt.Sprintf("DD_APM_INSTRUMENTATION_ENABLED=host DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=%s DD_SITE=\"datadoghq.com\" DD_REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)


### PR DESCRIPTION
This PR:
- Moves the installation of the installer at the top after input resolution
- Adds a way to check if a package is installed by the installer
- Filter out packages installed by the installer when installing package manager packages
- Avoid running the setup script of the injector if its installed with the installer