### PR TITLE
Add the standalone ASM env var

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1641,6 +1641,7 @@ function manage_client_libraries_security_config(){
   local asm_enable="$3"
   local iast_enable="$4"
   local sca_enable="$5"
+  local standalone_enable="$6"
   if [ -n "$asm_enable" ]; then
     $sudo_cmd sed -i -n -e '/^DD_APPSEC_ENABLED=/!p' -e "\$aDD_APPSEC_ENABLED=$asm_enable" "$etc_environment"
   fi
@@ -1649,6 +1650,9 @@ function manage_client_libraries_security_config(){
   fi
   if [ -n "$sca_enable" ]; then
     $sudo_cmd sed -i -n -e '/^DD_APPSEC_SCA_ENABLED=/!p' -e "\$aDD_APPSEC_SCA_ENABLED=$sca_enable" "$etc_environment"
+  fi
+  if [ -n "$standalone_enable" ]; then
+    $sudo_cmd sed -i -n -e '/^DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED=/!p' -e "\$aDD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED=$standalone_enable" "$etc_environment"
   fi
 }
 # "Main" configuration update
@@ -1671,7 +1675,7 @@ elif [ ! "$no_agent" ]; then
   manage_security_and_system_probe_config "$sudo_cmd" "$security_agent_config_file" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
 fi
 
-manage_client_libraries_security_config "$sudo_cmd" "/etc/environment" "$DD_APPSEC_ENABLED" "$DD_IAST_ENABLED" "$DD_APPSEC_SCA_ENABLED"
+manage_client_libraries_security_config "$sudo_cmd" "/etc/environment" "$DD_APPSEC_ENABLED" "$DD_IAST_ENABLED" "$DD_APPSEC_SCA_ENABLED" "$DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED"
 
 if [ ! "$no_agent" ]; then
   $sudo_cmd chown dd-agent:dd-agent "$config_file"

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -254,21 +254,24 @@ testFullConfig(){
 testManageClientLibrariesSecurityConfig() {
   rm $environment_file
   echo 'PATH="/usr/local/sbin"' > $environment_file
-  manage_client_libraries_security_config "sudo" $environment_file "" "" ""
+  manage_client_libraries_security_config "sudo" $environment_file "" "" "" ""
   grep -q "DD_APPSEC_ENABLED" $environment_file
   assertEquals 1 $?
   grep -q "DD_IAST_ENABLED" $environment_file
   assertEquals 1 $?
   grep -q "DD_APPSEC_SCA_ENABLED" $environment_file
   assertEquals 1 $?
-  manage_client_libraries_security_config "sudo" $environment_file true "" ""
+  manage_client_libraries_security_config "sudo" $environment_file true "" "" ""
   grep -q "DD_APPSEC_ENABLED=true" $environment_file
   assertEquals 0 $?
-  manage_client_libraries_security_config "sudo" $environment_file "" true ""
+  manage_client_libraries_security_config "sudo" $environment_file "" true "" ""
   grep -q "DD_IAST_ENABLED=true" $environment_file
   assertEquals 0 $?
-  manage_client_libraries_security_config "sudo" $environment_file "" "" false
+  manage_client_libraries_security_config "sudo" $environment_file "" "" false ""
   grep -q "DD_APPSEC_SCA_ENABLED=false" $environment_file
+  assertEquals 0 $?
+  manage_client_libraries_security_config "sudo" $environment_file "" "" "" true
+  grep -q "DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED=true" $environment_file
   assertEquals 0 $?
 }
 


### PR DESCRIPTION
Wonder if we should consider a generic mechanism to forward all env var starting `DD_`? Possibly tricky in bash?