### PR TITLE
[2024 GPG Key Rotation] Import new GPG future key

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -22,14 +22,16 @@ LEGACY_CONF="$LEGACY_ETCDIR/datadog.conf"
 # DATADOG_APT_KEY_382E94DE.public expires in 2022
 # DATADOG_APT_KEY_F14F620E.public expires in 2032
 # DATADOG_APT_KEY_C0962C7D.public expires in 2028
-APT_GPG_KEYS=("DATADOG_APT_KEY_CURRENT.public" "DATADOG_APT_KEY_C0962C7D.public" "DATADOG_APT_KEY_F14F620E.public" "DATADOG_APT_KEY_382E94DE.public")
+# DATADOG_APT_KEY_06462314.public expires in 2033
+APT_GPG_KEYS=("DATADOG_APT_KEY_CURRENT.public" "DATADOG_APT_KEY_06462314.public" "DATADOG_APT_KEY_C0962C7D.public" "DATADOG_APT_KEY_F14F620E.public" "DATADOG_APT_KEY_382E94DE.public")
 
 # DATADOG_RPM_KEY_CURRENT.public always contains key used to sign current
 # repodata and newly released packages
 # DATADOG_RPM_KEY_E09422B3.public expires in 2022
 # DATADOG_RPM_KEY_FD4BF915.public expires in 2024
 # DATADOG_RPM_KEY_B01082D3.public expires in 2028
-RPM_GPG_KEYS=("DATADOG_RPM_KEY_CURRENT.public" "DATADOG_RPM_KEY_B01082D3.public" "DATADOG_RPM_KEY_FD4BF915.public" "DATADOG_RPM_KEY_E09422B3.public")
+# DATADOG_RPM_KEY_4F09D16B.public expires in 2033
+RPM_GPG_KEYS=("DATADOG_RPM_KEY_CURRENT.public" "DATADOG_RPM_KEY_4F09D16B.public" "DATADOG_RPM_KEY_B01082D3.public" "DATADOG_RPM_KEY_FD4BF915.public" "DATADOG_RPM_KEY_E09422B3.public")
 
 # DATADOG_RPM_KEY.public (4172A230) was only useful to install old (< 6.14) Agent packages.
 # We no longer add it and we explicitly remove it.


### PR DESCRIPTION
WIth the 2024 GPG key rotation ongoing customer will need to start trusting a new future GPG key that will be used in 2028.