### PR TITLE
Add a check to forbid APM injection installation on redhat 6

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1057,6 +1057,13 @@ if [ "$OS" == "RedHat" ]; then
                 exit;
             fi
         else
+            if [ ${#apm_libraries[@]} -gt 0 ]; then
+              ERROR_MESSAGE="APM injection is not supported on $DISTRIBUTION  < 7"
+              ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
+              echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
+              report_telemetry
+              exit 1;
+            fi
             if ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
                 echo -e "  \033[33m$nice_flavor $agent_major_version.51 is the last supported version on $DISTRIBUTION $release_version. Installing $agent_major_version.51 now.\n\033[0m"
                 agent_minor_version=51

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1048,6 +1048,13 @@ if [ "$OS" == "RedHat" ]; then
         release_version=7
     fi
     if { [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ]; } && [ "$release_version" -lt 7 ]; then
+        if [ ${#apm_libraries[@]} -gt 0 ]; then
+          ERROR_MESSAGE="APM injection is not supported on $DISTRIBUTION  < 7"
+          ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
+          echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
+          report_telemetry
+          exit 1;
+        fi
         if [ -n "$agent_minor_version_without_patch" ]; then
             if [ "$agent_minor_version_without_patch" -ge "52" ]; then
                 ERROR_MESSAGE="$DISTRIBUTION < 7 only supports $nice_flavor $agent_major_version up to $agent_major_version.51."
@@ -1057,13 +1064,6 @@ if [ "$OS" == "RedHat" ]; then
                 exit;
             fi
         else
-            if [ ${#apm_libraries[@]} -gt 0 ]; then
-              ERROR_MESSAGE="APM injection is not supported on $DISTRIBUTION  < 7"
-              ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
-              echo -e "\033[31m$ERROR_MESSAGE\033[0m\n"
-              report_telemetry
-              exit 1;
-            fi
             if ! echo "$agent_flavor" | grep '[0-9]' > /dev/null; then
                 echo -e "  \033[33m$nice_flavor $agent_major_version.51 is the last supported version on $DISTRIBUTION $release_version. Installing $agent_major_version.51 now.\n\033[0m"
                 agent_minor_version=51


### PR DESCRIPTION
Installation was already broken because the installer is linked to a newer version of libc, but we want to exit early rather than installing broken packages.