### PR TITLE
(fleet) restart the installer service when remote updates are enabled

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -915,6 +915,10 @@ if [ -n "$fips_mode" ]; then
   services+=("datadog-fips-proxy")
 fi
 
+if [ -n "$remote_updates" ]; then
+  services+=("datadog-installer")
+fi
+
 if [ -z "$etcdir" ]; then
     etcdir="/etc/datadog-agent"
 fi


### PR DESCRIPTION
This PR adds the installer service to the services to restart after the config has been populated.