### PR TITLE
(fleet) add suse support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -277,7 +277,6 @@ e2e:
     - if: $CI_COMMIT_TAG
       when: always
     - when: on_success
-      allow_failure: true
   variables:
     KUBERNETES_MEMORY_REQUEST: 12Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -319,6 +319,7 @@ e2e:
           - RedHat_CentOS_7
           - RedHat_8
           - Amazon_Linux_2023
+          - openSUSE_15
         EXTRA_PARAMS:
           - --run TestInstallUpdaterSuite
       - FLAVOR: datadog-agent

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -581,11 +581,6 @@ function install_installer() {
         return 0
     fi
 
-    # The installer is only supported on Debian and RedHat based distributions for now
-    if [ "$os" != "Debian" ] && [ "$os" != "RedHat" ]; then
-        return 0
-    fi
-
     trace_id=$(od -An -N8 -tu8 < /dev/urandom | tr -d ' ')
     start_time=$(date +%s%N)
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -515,6 +515,9 @@ function _install_installer() {
     elif [ "$os" == "RedHat" ]; then
         echo -e "\033[34m\n* Installing the Datadog installer\n\033[0m"
         $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install "datadog-installer" || $sudo_cmd yum -y install "datadog-installer" || return $?
+    elif [ "$os" == "SUSE" ]; then
+        echo -e "\033[34m\n* Installing the Datadog installer\n\033[0m"
+	$sudo_cmd zypper --non-interactive --no-refresh install "datadog-installer" || return $?
     else
         return 0
     fi

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -38,6 +38,9 @@ func (s *installUpdaterTestSuite) TestInstallUpdater() {
 	t := s.T()
 	vm := s.Env().VM
 	cmd := fmt.Sprintf("DD_INSTALLER=true DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
+	if _, err := vm.ExecuteWithError("command -v zypper"); err == nil {
+		cmd = fmt.Sprintf("%s %s", "REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta", cmd)
+	}
 	output := vm.Execute(cmd)
 	t.Log(output)
 	defer s.purge()

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -37,7 +37,7 @@ func TestInstallUpdaterSuite(t *testing.T) {
 func (s *installUpdaterTestSuite) TestInstallUpdater() {
 	t := s.T()
 	vm := s.Env().VM
-	cmd := fmt.Sprintf("DD_INSTALLER=true DD_APM_INSTRUMENTATION_ENABLED=host DD_APM_INSTRUMENTATION_LANGUAGES=\" \" DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
+	cmd := fmt.Sprintf("DD_INSTALLER=true DD_API_KEY=%s DD_SITE=\"datadoghq.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.Execute(cmd)
 	t.Log(output)
 	defer s.purge()
@@ -57,6 +57,9 @@ const isInstalledScript = `#!/bin/bash
 
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
+	if _, err = vm.ExecuteWithError("command -v zypper"); err == nil {
+		t.Skip("zypper does not support apm packages")
+	}
 	vm := s.Env().VM
 	vm.Execute("echo 'export PATH=/usr/local/bin:$PATH' | sudo tee -a /etc/profile")
 	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -57,10 +57,10 @@ const isInstalledScript = `#!/bin/bash
 
 func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalledByPackageManager() {
 	t := s.T()
-	if _, err = vm.ExecuteWithError("command -v zypper"); err == nil {
+	vm := s.Env().VM
+	if _, err := vm.ExecuteWithError("command -v zypper"); err == nil {
 		t.Skip("zypper does not support apm packages")
 	}
-	vm := s.Env().VM
 	vm.Execute("echo 'export PATH=/usr/local/bin:$PATH' | sudo tee -a /etc/profile")
 	vm.Execute("echo '" + isInstalledScript + "' | sudo tee /usr/local/bin/datadog-installer && sudo chmod +x /usr/local/bin/datadog-installer")
 	_, _ = vm.ExecuteWithError("echo '" + isInstalledScript + "' | sudo tee /sbin/datadog-installer && sudo chmod +x /sbin/datadog-installer")


### PR DESCRIPTION
[link to updater suite test on suse](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/526109037)

Removed e2e `allow_failure: true` to properly catch failing tests. They could fail silently and be picked only at release time, as releases enforce that all tests must pass.