### PR TITLE
fix unknown

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -320,6 +320,9 @@ function getMapData() {
              "datadog-heroku-agent")
                 DATA="Datadog Heroku Agent"
                 ;;
+             "datadog-installer")
+                DATA="Datadog Installer"
+                ;;
               *)
                 DATA="Unknown"
                 ;;


### PR DESCRIPTION
Fixes `Unknown` logs for datadog-installer

<img width="983" alt="Screenshot 2024-05-30 at 15 07 24" src="https://github.com/DataDog/agent-linux-install-script/assets/22001182/fb784754-670f-42f2-aa82-6015b692d53b">
