### PR TITLE
PROF-9889: Add support for propagating DD_PROFILING_ENABLED

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1747,6 +1747,14 @@ function manage_client_libraries_security_config(){
     $sudo_cmd sed -i -n -e '/^DD_APPSEC_SCA_ENABLED=/!p' -e "\$aDD_APPSEC_SCA_ENABLED=$sca_enable" "$etc_environment"
   fi
 }
+function manage_client_libraries_profiling_config(){
+  local sudo_cmd="$1"
+  local etc_environment="$2"
+  local profiling_enable="$3"
+  if [ -n "$profiling_enable" ]; then
+    $sudo_cmd sed -i -n -e '/^DD_PROFILING_ENABLED=/!p' -e "\$aDD_PROFILING_ENABLED=$profiling_enable" "$etc_environment"
+  fi
+}
 # "Main" configuration update
 if [ -e "$config_file" ] && [ -z "$upgrade" ]; then
   printf "\033[34m\n* Keeping old $config_file configuration file\n\033[0m\n"
@@ -1769,6 +1777,7 @@ elif [ ! "$no_agent" ]; then
 fi
 
 manage_client_libraries_security_config "$sudo_cmd" "/etc/environment" "$DD_APPSEC_ENABLED" "$DD_IAST_ENABLED" "$DD_APPSEC_SCA_ENABLED"
+manage_client_libraries_profiling_config "$sudo_cmd" "/etc/environment" "$DD_PROFILING_ENABLED"
 
 if [ ! "$no_agent" ]; then
   $sudo_cmd chown dd-agent:dd-agent "$config_file"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -934,6 +934,7 @@ fi
 config_file_fips=$etcdirfips/datadog-fips-proxy.cfg
 system_probe_config_file=$etcdir/system-probe.yaml
 security_agent_config_file=$etcdir/security-agent.yaml
+environment_file=/etc/environment
 
 agent_major_version=AGENT_MAJOR_VERSION_PLACEHOLDER
 # shellcheck disable=SC2050
@@ -1776,8 +1777,8 @@ elif [ ! "$no_agent" ]; then
   manage_security_and_system_probe_config "$sudo_cmd" "$security_agent_config_file" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
 fi
 
-manage_client_libraries_security_config "$sudo_cmd" "/etc/environment" "$DD_APPSEC_ENABLED" "$DD_IAST_ENABLED" "$DD_APPSEC_SCA_ENABLED"
-manage_client_libraries_profiling_config "$sudo_cmd" "/etc/environment" "$DD_PROFILING_ENABLED"
+manage_client_libraries_security_config "$sudo_cmd" "$environment_file" "$DD_APPSEC_ENABLED" "$DD_IAST_ENABLED" "$DD_APPSEC_SCA_ENABLED"
+manage_client_libraries_profiling_config "$sudo_cmd" "$environment_file" "$DD_PROFILING_ENABLED"
 
 if [ ! "$no_agent" ]; then
   $sudo_cmd chown dd-agent:dd-agent "$config_file"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1753,7 +1753,11 @@ function manage_client_libraries_profiling_config(){
   local etc_environment="$2"
   local profiling_enable="$3"
   if [ -n "$profiling_enable" ]; then
-    $sudo_cmd sed -i -n -e '/^DD_PROFILING_ENABLED=/!p' -e "\$aDD_PROFILING_ENABLED=$profiling_enable" "$etc_environment"
+    if [ ! -s "$etc_environment" ]; then
+      $sudo_cmd echo "DD_PROFILING_ENABLED=$profiling_enable" > "$etc_environment"
+    else
+      $sudo_cmd sed -i -n -e '/^DD_PROFILING_ENABLED=/!p' -e "\$aDD_PROFILING_ENABLED=$profiling_enable" "$etc_environment"
+    fi
   fi
 }
 # "Main" configuration update

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -273,14 +273,33 @@ testManageClientLibrariesSecurityConfig() {
 }
 
 ### Manage client libraries profiling config
-testManageClientLibrariesProfilingConfig() {
+testManageClientLibrariesProfilingConfig_NotSpecified_FileDoesNotExist() {
+  rm $environment_file
+  manage_client_libraries_profiling_config "sudo" $environment_file ""
+  assertFalse "[ -s $environment_file ]"
+}
+testManageClientLibrariesProfilingConfig_NotSpecified_FileExists() {
   rm $environment_file
   echo 'PATH="/usr/local/sbin"' > $environment_file
   manage_client_libraries_profiling_config "sudo" $environment_file ""
   grep -q "DD_PROFILING_ENABLED" $environment_file
   assertEquals 1 $?
+  grep -q "PATH" $environment_file
+  assertEquals 0 $?
+}
+testManageClientLibrariesProfilingConfig_Specified_FileDoesNotExist() {
+  rm $environment_file
   manage_client_libraries_profiling_config "sudo" $environment_file "auto"
   grep -q "DD_PROFILING_ENABLED=auto" $environment_file
+  assertEquals 0 $?
+}
+testManageClientLibrariesProfilingConfig_Specified_FileExists() {
+  rm $environment_file
+  echo 'PATH="/usr/local/sbin"' > $environment_file
+  manage_client_libraries_profiling_config "sudo" $environment_file "auto"
+  grep -q "DD_PROFILING_ENABLED=auto" $environment_file
+  assertEquals 0 $?
+  grep -q "PATH" $environment_file
   assertEquals 0 $?
 }
 

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -272,5 +272,17 @@ testManageClientLibrariesSecurityConfig() {
   assertEquals 0 $?
 }
 
+### Manage client libraries profiling config
+testManageClientLibrariesProfilingConfig() {
+  rm $environment_file
+  echo 'PATH="/usr/local/sbin"' > $environment_file
+  manage_client_libraries_profiling_config "sudo" $environment_file ""
+  grep -q "DD_PROFILING_ENABLED" $environment_file
+  assertEquals 1 $?
+  manage_client_libraries_profiling_config "sudo" $environment_file "auto"
+  grep -q "DD_PROFILING_ENABLED=auto" $environment_file
+  assertEquals 0 $?
+}
+
 # shellcheck source=/dev/null
 . shunit2


### PR DESCRIPTION
Adds support for handling `DD_PROFILING_ENABLED` in a similar vein to how `DD_IAST_ENABLED` and `DD_APPSEC_ENABLED` are propagated to `/etc/environment` in #157.

## Rationale
We want to get some customers on a private beta of profiling with SSI.

## Testing
Unit test added and confirmed to work with
```
make
python3 unit_tests/extract_functions.py
sudo ./unit_tests/test_install_script.sh
```