### PR TITLE
feat(ci): Add default retry for infra failures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,16 @@ variables:
   DD_ENV: testenv
 
 default:
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure
   # Handle inputs when running as a downstream pipeline from the datadog-agent repo
   before_script:
     - '[ -z "$MAJOR_VERSION" ] && export MAJOR_VERSION=${DEFAULT_MAJOR_VERSION}'


### PR DESCRIPTION
Copied [definition](https://github.com/DataDog/datadog-agent/blob/main/.gitlab-ci.yml#L48C1-L57C31) from `datadog-agent`, this should reduce instabilities, especially `runner-system-failure` like [here](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/533660409)