### PR TITLE
fix(debian): Only exclude pinned tracer versions from apt updates if they've been installed

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1376,8 +1376,10 @@ If the cause is unclear, please contact Datadog support.
 
     for pkg in "${packages_to_lock[@]}"
     do
-        # exclude pinned tracer versions from updates
-        $sudo_cmd apt-mark hold "${pkg}" >/dev/null 2>&1
+        if $sudo_cmd dpkg -l "${pkg}" >/dev/null 2>&1 ; then
+          # exclude pinned tracer versions from updates if they're installed through debs
+          $sudo_cmd apt-mark hold "${pkg}" >/dev/null 2>&1
+        fi
     done
 
     ERR_SUMMARY=$(grep "No space left on device" -C1 /tmp/ddog_install_error_msg || true)

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -167,20 +167,20 @@ fi
 
 if [ -n "$DD_APM_INSTRUMENTATION_ENABLED" ] || [ "${SCRIPT_FLAVOR}" == "docker_injection" ]; then
   if [[ "$OS_TYPE" == "ubuntu" ]]; then
-      ls /opt/datadog-packages/datadog-apm-inject || debsums -c datadog-apm-inject
-      ls /opt/datadog-packages/datadog-apm-library-dotnet || debsums -c datadog-apm-library-dotnet
-      ls /opt/datadog-packages/datadog-apm-library-java || debsums -c datadog-apm-library-java
-      ls /opt/datadog-packages/datadog-apm-library-js || debsums -c datadog-apm-library-js
-      ls /opt/datadog-packages/datadog-apm-library-python || debsums -c datadog-apm-library-python
-      ls /opt/datadog-packages/datadog-apm-library-ruby || debsums -c datadog-apm-library-ruby
+      test -d /opt/datadog-packages/datadog-apm-inject/stable || debsums -c datadog-apm-inject
+      test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable || debsums -c datadog-apm-library-dotnet
+      test -d /opt/datadog-packages/datadog-apm-library-java/stable || debsums -c datadog-apm-library-java
+      test -d /opt/datadog-packages/datadog-apm-library-js/stable || debsums -c datadog-apm-library-js
+      test -d /opt/datadog-packages/datadog-apm-library-python/stable || debsums -c datadog-apm-library-python
+      test -d /opt/datadog-packages/datadog-apm-library-ruby/stable || debsums -c datadog-apm-library-ruby
       echo "[OK] Inject libraries installed"
   else
-      ls /opt/datadog-packages/datadog-apm-inject || rpm --verify --nomode --nouser --nogroup datadog-apm-inject
-      ls /opt/datadog-packages/datadog-apm-library-dotnet || rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
-      ls /opt/datadog-packages/datadog-apm-library-java || rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
-      ls /opt/datadog-packages/datadog-apm-library-js || rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
-      ls /opt/datadog-packages/datadog-apm-library-python || rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
-      ls /opt/datadog-packages/datadog-apm-library-ruby || rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
+      test -d /opt/datadog-packages/datadog-apm-inject/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-inject
+      test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
+      test -d /opt/datadog-packages/datadog-apm-library-java/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
+      test -d /opt/datadog-packages/datadog-apm-library-js/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
+      test -d /opt/datadog-packages/datadog-apm-library-python/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
+      test -d /opt/datadog-packages/datadog-apm-library-ruby/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
       echo "[OK] Inject libraries installed"
   fi
 
@@ -206,19 +206,19 @@ fi
 
 if [ -n "$DD_APM_INSTRUMENTATION_LANGUAGES" ]; then
   if [[ "$OS_TYPE" == "ubuntu" ]]; then
-      ls /opt/datadog-packages/datadog-apm-library-dotnet || debsums -c datadog-apm-library-dotnet
-      ls /opt/datadog-packages/datadog-apm-library-java || debsums -c datadog-apm-library-java
-      ls /opt/datadog-packages/datadog-apm-library-js || debsums -c datadog-apm-library-js
-      ls /opt/datadog-packages/datadog-apm-library-python || debsums -c datadog-apm-library-python
-      ls /opt/datadog-packages/datadog-apm-library-ruby || debsums -c datadog-apm-library-ruby
-      echo "[OK] Inject libraries installed"
+    test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable || debsums -c datadog-apm-library-dotnet
+    test -d /opt/datadog-packages/datadog-apm-library-java/stable || debsums -c datadog-apm-library-java
+    test -d /opt/datadog-packages/datadog-apm-library-js/stable || debsums -c datadog-apm-library-js
+    test -d /opt/datadog-packages/datadog-apm-library-python/stable || debsums -c datadog-apm-library-python
+    test -d /opt/datadog-packages/datadog-apm-library-ruby/stable || debsums -c datadog-apm-library-ruby
+    echo "[OK] Inject libraries installed"
   else
-      ls /opt/datadog-packages/datadog-apm-library-dotnet || rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
-      ls /opt/datadog-packages/datadog-apm-library-java || rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
-      ls /opt/datadog-packages/datadog-apm-library-js || rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
-      ls /opt/datadog-packages/datadog-apm-library-python || rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
-      ls /opt/datadog-packages/datadog-apm-library-ruby || rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
-      echo "[OK] Inject libraries installed"
+    test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
+    test -d /opt/datadog-packages/datadog-apm-library-java/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
+    test -d /opt/datadog-packages/datadog-apm-library-js/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
+    test -d /opt/datadog-packages/datadog-apm-library-python/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
+    test -d /opt/datadog-packages/datadog-apm-library-ruby/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
+    echo "[OK] Inject libraries installed"
   fi
 fi
 

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -167,20 +167,20 @@ fi
 
 if [ -n "$DD_APM_INSTRUMENTATION_ENABLED" ] || [ "${SCRIPT_FLAVOR}" == "docker_injection" ]; then
   if [[ "$OS_TYPE" == "ubuntu" ]]; then
-      debsums -c datadog-apm-inject
-      debsums -c datadog-apm-library-dotnet
-      debsums -c datadog-apm-library-java
-      debsums -c datadog-apm-library-js
-      debsums -c datadog-apm-library-python
-      debsums -c datadog-apm-library-ruby
+      ls /opt/datadog-packages/datadog-apm-inject || debsums -c datadog-apm-inject
+      ls /opt/datadog-packages/datadog-apm-library-dotnet || debsums -c datadog-apm-library-dotnet
+      ls /opt/datadog-packages/datadog-apm-library-java || debsums -c datadog-apm-library-java
+      ls /opt/datadog-packages/datadog-apm-library-js || debsums -c datadog-apm-library-js
+      ls /opt/datadog-packages/datadog-apm-library-python || debsums -c datadog-apm-library-python
+      ls /opt/datadog-packages/datadog-apm-library-ruby || debsums -c datadog-apm-library-ruby
       echo "[OK] Inject libraries installed"
   else
-      rpm --verify --nomode --nouser --nogroup datadog-apm-inject
-      rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
-      rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
-      rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
-      rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
-      rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
+      ls /opt/datadog-packages/datadog-apm-inject || rpm --verify --nomode --nouser --nogroup datadog-apm-inject
+      ls /opt/datadog-packages/datadog-apm-library-dotnet || rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
+      ls /opt/datadog-packages/datadog-apm-library-java || rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
+      ls /opt/datadog-packages/datadog-apm-library-js || rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
+      ls /opt/datadog-packages/datadog-apm-library-python || rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
+      ls /opt/datadog-packages/datadog-apm-library-ruby || rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
       echo "[OK] Inject libraries installed"
   fi
 
@@ -206,19 +206,19 @@ fi
 
 if [ -n "$DD_APM_INSTRUMENTATION_LANGUAGES" ]; then
   if [[ "$OS_TYPE" == "ubuntu" ]]; then
-    debsums -c datadog-apm-library-dotnet
-    debsums -c datadog-apm-library-java
-    debsums -c datadog-apm-library-js
-    debsums -c datadog-apm-library-python
-    debsums -c datadog-apm-library-ruby
-    echo "[OK] Inject libraries installed"
+      ls /opt/datadog-packages/datadog-apm-library-dotnet || debsums -c datadog-apm-library-dotnet
+      ls /opt/datadog-packages/datadog-apm-library-java || debsums -c datadog-apm-library-java
+      ls /opt/datadog-packages/datadog-apm-library-js || debsums -c datadog-apm-library-js
+      ls /opt/datadog-packages/datadog-apm-library-python || debsums -c datadog-apm-library-python
+      ls /opt/datadog-packages/datadog-apm-library-ruby || debsums -c datadog-apm-library-ruby
+      echo "[OK] Inject libraries installed"
   else
-    rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
-    rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
-    rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
-    rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
-    rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
-    echo "[OK] Inject libraries installed"
+      ls /opt/datadog-packages/datadog-apm-library-dotnet || rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
+      ls /opt/datadog-packages/datadog-apm-library-java || rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
+      ls /opt/datadog-packages/datadog-apm-library-js || rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
+      ls /opt/datadog-packages/datadog-apm-library-python || rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
+      ls /opt/datadog-packages/datadog-apm-library-ruby || rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
+      echo "[OK] Inject libraries installed"
   fi
 fi
 


### PR DESCRIPTION
Today on an Debian-like OS, when a tracer version is pinned, it's excluded from APT updates regardless of whether it has been installed or not. It worked fine before as it was always installed through APT, but now it can and will be installed with the installer by default: running apt-mark will fail the install script.

This PR fixes it by checking that the tracer has been installed through APT before running apt-mark. It also fixes injection tests.