### PR TITLE
upgrade(installer): Add telemetry on is-installed operation

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -533,8 +533,11 @@ function _install_installer() {
 
 function is_installed_by_installer() {
     local sudo_cmd="$1"
+    local package="$2"
+    local command_prefix
     if command -v datadog-installer >/dev/null 2>&1; then
-        $sudo_cmd datadog-installer is-installed "$2"
+        command_prefix="${sudo_cmd:+$sudo_cmd -E}"
+        $command_prefix sh -c "DD_API_KEY=\"${apikey}\" DD_SITE=\"${site}\" DATADOG_TRACE_ID=\"${trace_id}\" DATADOG_PARENT_ID=\"${trace_id}\" datadog-installer is-installed \"${package}\""
         local status=$?
         if [ $status -eq 0 ]; then
             return 0


### PR DESCRIPTION
There was no environment variable passed to the `is-installed` operation, which meant:
- A warning log about no telemetry was emitted per package check
- No telemetry on is-installed

This PR fixes both by adding the telemetry environment variables to the is-installed operation