### PR TITLE
fix(installer): Don't override installer install_info

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1863,7 +1863,7 @@ install_method:
   installer_version: install_script-$install_script_version
 "
 
-if [ ! "$no_agent" ]; then
+if [ ! "$no_agent" ] && ! is_installed_by_installer "$sudo_cmd" "datadog-agent"; then
   $sudo_cmd sh -c "echo '$install_signature' > $etcdir/install.json"
   $sudo_cmd chmod 644 "$etcdir/install.json"
   $sudo_cmd sh -c "exec cat > $etcdir/install_info " <<EOF


### PR DESCRIPTION
When installing the agent with the installer, the install info is set [here](https://github.com/DataDog/datadog-agent/blob/1d08a6a9783fe271ea3813ddf9abf60244abdf2c/pkg/fleet/installer/service/datadog_agent.go#L106-L108).

Today it's overridden later on in the install script: this PR fixes it.