### PR TITLE
(fleet) enable remote updates on existing installs

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1782,14 +1782,15 @@ elif [ ! "$no_agent" ]; then
     update_hostname "$sudo_cmd" "$hostname" "$config_file"
     update_hosttags "$sudo_cmd" "$host_tags" "$config_file"
     update_env "$sudo_cmd" "$dd_env" "$config_file"
-    update_remote_updates "$sudo_cmd" "$remote_updates" "$fips_mode" "$site" "$config_file"
-    update_installer_registry "$sudo_cmd" "$installer_registry_url" "$installer_registry_auth" "$config_file"
   fi
   manage_security_and_system_probe_config "$sudo_cmd" "$security_agent_config_file" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
 fi
 
 manage_client_libraries_security_config "$sudo_cmd" "$environment_file" "$DD_APPSEC_ENABLED" "$DD_IAST_ENABLED" "$DD_APPSEC_SCA_ENABLED"
 manage_client_libraries_profiling_config "$sudo_cmd" "$environment_file" "$DD_PROFILING_ENABLED"
+
+update_remote_updates "$sudo_cmd" "$remote_updates" "$fips_mode" "$site" "$config_file"
+update_installer_registry "$sudo_cmd" "$installer_registry_url" "$installer_registry_auth" "$config_file"
 
 if [ ! "$no_agent" ]; then
   $sudo_cmd chown dd-agent:dd-agent "$config_file"


### PR DESCRIPTION
The current code only modifies datadog.yaml if the file has not been created yet. For the installer settings we need to be able to migrate and as such we need to override the agent settings.