### PR TITLE
Pass flavor to tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,6 +70,7 @@ unit_tests:
   dependencies: ["generate-scripts"]
   variables:
     SCRIPT: "install_script_agent${MAJOR_VERSION}.sh"
+    DD_AGENT_FLAVOR: $FLAVOR
   script:
     - ./test/localtest.sh
   # retry the job in case of failure, we might have network issues downloading the image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,6 +128,8 @@ test_centos6:
 
 test:
   extends: .test
+  variables:
+    MAJOR_VERSION: 7
   parallel:
     # NOTE: to keep the matrix reasonably sized, we don't test everything everywhere
     # for example, it's ok to test getting specific flavor/minor version only on
@@ -135,30 +137,20 @@ test:
     matrix:
       - IMAGE: centos:centos7
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: 7
       - IMAGE: rockylinux:9.0
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: 7
       - IMAGE: amazonlinux:2
-        MAJOR_VERSION: 7
       - IMAGE: amazonlinux:2022
-        MAJOR_VERSION: 7
       - IMAGE: ubuntu:14.04
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: 7
       - IMAGE: debian:10.9
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: 7
       - IMAGE: ubuntu:22.04
-        MAJOR_VERSION: 7
       - IMAGE: opensuse/archive:42.3
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: 7
       - IMAGE: opensuse/leap:15.4
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: 7
       - IMAGE: debian:12.1
-        MAJOR_VERSION: 7
   artifacts:
     name: "artifacts"
     paths:
@@ -166,30 +158,22 @@ test:
 
 test_agent6:
   extends: .test
+  variables:
+    MAJOR_VERSION: 6
   parallel:
     # NOTE: Agent 6 only exists for the datadog-agent "flavor".
     # Since we've dropped Agent 6 from the regular release cadence, it makes sense to separate these
     matrix:
       - IMAGE: centos:centos7
-        MAJOR_VERSION: 6
       - IMAGE: rockylinux:9.0
-        MAJOR_VERSION: 6
       - IMAGE: amazonlinux:2
-        MAJOR_VERSION: 6
       - IMAGE: amazonlinux:2022
-        MAJOR_VERSION: 6
       - IMAGE: ubuntu:14.04
-        MAJOR_VERSION: 6
       - IMAGE: debian:10.9
-        MAJOR_VERSION: 6
       - IMAGE: ubuntu:22.04
-        MAJOR_VERSION: 6
       - IMAGE: opensuse/archive:42.3
-        MAJOR_VERSION: 6
       - IMAGE: opensuse/leap:15.4
-        MAJOR_VERSION: 6
       - IMAGE: debian:12.1
-        MAJOR_VERSION: 6
 
 .test-yaml:
   image: registry.ddbuild.io/images/mirror/python:3.9.6-alpine3.14
@@ -202,17 +186,17 @@ test_agent6:
 test-yaml-redhat:
   extends: .test-yaml
   needs:
-    - "test: [centos:centos7, datadog-agent, 7]"
+    - "test: [centos:centos7, datadog-agent]"
 
 test-yaml-debian:
   extends: .test-yaml
   needs:
-    - "test: [ubuntu:14.04, datadog-agent, 7]"
+    - "test: [ubuntu:14.04, datadog-agent]"
 
 test-yaml-suse:
   extends: .test-yaml
   needs:
-    - "test: [opensuse/archive:42.3, datadog-agent, 7]"
+    - "test: [opensuse/archive:42.3, datadog-agent]"
 
 test-apm-injection:
   image: registry.ddbuild.io/images/mirror/${IMAGE}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,8 +120,11 @@ test_centos6:
   parallel:
     matrix:
       - IMAGE: centos:centos6
+        FLAVOR: datadog-agent
+        MAJOR_VERSION: 6
+      - IMAGE: centos:centos6
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
 
 test:
   extends: .test
@@ -132,34 +135,61 @@ test:
     matrix:
       - IMAGE: centos:centos7
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
       - IMAGE: rockylinux:9.0
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
       - IMAGE: amazonlinux:2
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
       - IMAGE: amazonlinux:2022
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
       - IMAGE: ubuntu:14.04
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
       - IMAGE: debian:10.9
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
       - IMAGE: ubuntu:22.04
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
       - IMAGE: opensuse/archive:42.3
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
       - IMAGE: opensuse/leap:15.4
         FLAVOR: [datadog-agent, datadog-dogstatsd, datadog-iot-agent]
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
       - IMAGE: debian:12.1
-        MAJOR_VERSION: [6, 7]
+        MAJOR_VERSION: 7
   artifacts:
     name: "artifacts"
     paths:
       - artifacts/
+
+test_agent6:
+  extends: .test
+  parallel:
+    # NOTE: Agent 6 only exists for the datadog-agent "flavor".
+    # Since we've dropped Agent 6 from the regular release cadence, it makes sense to separate these
+    matrix:
+      - IMAGE: centos:centos7
+        MAJOR_VERSION: 6
+      - IMAGE: rockylinux:9.0
+        MAJOR_VERSION: 6
+      - IMAGE: amazonlinux:2
+        MAJOR_VERSION: 6
+      - IMAGE: amazonlinux:2022
+        MAJOR_VERSION: 6
+      - IMAGE: ubuntu:14.04
+        MAJOR_VERSION: 6
+      - IMAGE: debian:10.9
+        MAJOR_VERSION: 6
+      - IMAGE: ubuntu:22.04
+        MAJOR_VERSION: 6
+      - IMAGE: opensuse/archive:42.3
+        MAJOR_VERSION: 6
+      - IMAGE: opensuse/leap:15.4
+        MAJOR_VERSION: 6
+      - IMAGE: debian:12.1
+        MAJOR_VERSION: 6
 
 .test-yaml:
   image: registry.ddbuild.io/images/mirror/python:3.9.6-alpine3.14


### PR DESCRIPTION
At some point, the passing of the flavor to the bash-based tests was lost and we're installing the same datadog-agent in all testing jobs.

This fixes that by passing the necessary environment variable. It also separates Agent 6 jobs into a separate set of jobs, because:
- It doesn't make sense to test Agent 6 on "alternative flavors", the test script will just simply pass without doing anything, which is a bit unnecessary (why spin up a bunch of runners just to do nothing).
- As we're no longer releasing Agent 6 from datadog-agent's main, this separation can be a first step towards adding some rule to not trigger Agent 6 tests when not applicable.

The regression was probably introduced in https://github.com/DataDog/agent-linux-install-script/pull/121.