### PR TITLE
fix(install-script): fix stop instructions not being ran properly when DD_INSTALL_ONLY is set

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1962,10 +1962,10 @@ for current_service in "${services[@]}"; do
       if [[ $current_service == "datadog-agent" ]]; then
         # Stop all the related services 
         # https://github.com/DataDog/datadog-agent/blob/def18e3815c6cc67d8669408032961804821687a/omnibus/package-scripts/agent-rpm/preinst#L16-L20
-        "${stop_instructions}-process" || true
-        "${stop_instructions}-sysprobe" || true
-        "${stop_instructions}-trace" || true
-        "${stop_instructions}-security" || true
+        eval "${stop_instructions}-process" || true
+        eval "${stop_instructions}-sysprobe" || true
+        eval "${stop_instructions}-trace" || true
+        eval "${stop_instructions}-security" || true
       fi
     fi
   

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1962,10 +1962,10 @@ for current_service in "${services[@]}"; do
       if [[ $current_service == "datadog-agent" ]]; then
         # Stop all the related services 
         # https://github.com/DataDog/datadog-agent/blob/def18e3815c6cc67d8669408032961804821687a/omnibus/package-scripts/agent-rpm/preinst#L16-L20
-        eval "${stop_instructions}-process" || true
-        eval "${stop_instructions}-sysprobe" || true
-        eval "${stop_instructions}-trace" || true
-        eval "${stop_instructions}-security" || true
+        eval "${stop_instructions}-process || true"
+        eval "${stop_instructions}-sysprobe || true"
+        eval "${stop_instructions}-trace || true"
+        eval "${stop_instructions}-security || true" 
       fi
     fi
   


### PR DESCRIPTION
This PR should fix the following:
```
Stopping service datadog-agent that was launched during the package installation.
[539](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/598331734#L539)        bash: line 1964: sudo systemctl stop datadog-agent-process: command not found
[540](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/598331734#L540)        bash: line 1965: sudo systemctl stop datadog-agent-sysprobe: command not found
[541](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/598331734#L541)        bash: line 1966: sudo systemctl stop datadog-agent-trace: command not found
[542](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/598331734#L542)        bash: line 1967: sudo systemctl stop datadog-agent-security: command not found
```

Example: https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/598331734

That's because the shell interprets `sudo systemctl` as a single argument. Example:
```
[ec2-user@ip-10-1-60-26 ~]$ a="sudo systemctl"
[ec2-user@ip-10-1-60-26 ~]$ "${a}"
-bash: sudo systemctl : commande introuvable
[ec2-user@ip-10-1-60-26 ~]$ ${a}
UNIT                                                                    LOAD   ACTIVE     SUB       JOB   DESCRIPTION
proc-sys-fs-binfmt_misc.automount                                       loaded active     waiting         Arbitrary Executable File Formats File System Automount Point
sys-devices-pci0000:00-0000:00:04.0-nvme-nvme0-nvme0n1-nvme0n1p1.device loaded active     plugged         Amazon Elastic Block Store 1
...
```