### PR TITLE
chore(github): reduce workflow token permission

### DIFF
--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [closed]
 
+permissions: {}
+
 jobs:
   run_slapr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[JIRA-510](https://datadoghq.atlassian.net/browse/BARX-510)

Github token permissions should follow the [least privilege principle](https://datadoghq.atlassian.net/wiki/x/TIVE6Q)

Reset workflow permissions to validate we can enable `read-only` default permissions at repository level to provide a strong baseline protection measure

[JIRA-510]: https://datadoghq.atlassian.net/browse/JIRA-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ