### PR TITLE
Add unconditional retries for bash-based tests that run yum

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,6 +141,8 @@ test_opensuse13:
 # CentOS/RHEL 6 only support Datadog Agent version up 6.51, hence these tests should not be launched on pipelines triggered by datadog-agent pipelines
 test_centos6:
   extends: .test
+  # Unconditionally retry
+  retry: 3
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
   parallel:
@@ -154,6 +156,8 @@ test_centos6:
 
 test:
   extends: .test
+  # Unconditionally retry
+  retry: 3
   variables:
     MAJOR_VERSION: 7
   parallel:
@@ -184,6 +188,8 @@ test:
 
 test_agent6:
   extends: .test
+  # Unconditionally retry
+  retry: 3
   variables:
     MAJOR_VERSION: 6
   parallel:


### PR DESCRIPTION
Mitigation for #incident-29487.

We've seen for a while occasional flakes on the shell-based tests on yum-based systems, such as https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/598453648, which fail with a `Exiting on user cancel` message.

Since we're unable to find the source of the issue but the jobs consistently succeed on retry, we're adding some unconditional retries for the affected jobs as a workaround.