### PR TITLE
Dump systemd logs on uninstall failures

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -287,6 +287,14 @@ func (s *linuxInstallerTestSuite) assertUninstall() {
 			assertFileNotExists(c, vm, fmt.Sprintf("/opt/%s", s.baseName))
 		}
 	}, 10*time.Second, time.Second)
+	if t.Failed() {
+		stdout, err := vm.Execute("journalctl --no-pager")
+		if err != nil {
+			t.Logf("Failed to get journalctl logs: %s", err)
+		} else {
+			t.Logf("journalctl logs:\n%s", stdout)
+		}
+	}
 }
 
 func (s *linuxInstallerTestSuite) purge() {


### PR DESCRIPTION
In [this](https://github.com/DataDog/agent-linux-install-script/pull/261) PR we added a systemd logs dump in case of a failure when we look at whether services are active or not but it's never triggered.

We're still trying to understand the issue here https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/617935559
From the tests prior to this one, the service seems to be removed and the pid file stays.