### PR TITLE
(fleet) fix network telemetry

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -409,11 +409,6 @@ function report_installer_telemetry() {
         "runtime_id": "${trace_id}",
         "seq_id": 1,
         "origin": "linux-install-script",
-        "network": {
-            "gcr.io": "$(json_escape "$(curl -I --max-time 5 -s -o /dev/null -w "%{http_code}" "https://gcr.io/v2/datadoghq/installer-package/manifests/latest")")",
-            "install.datadoghq.com": "$(json_escape "$(curl -I --max-time 5 -s -o /dev/null -w "%{http_code}" "https://install.datadoghq.com/scripts/install_script_agent7.sh")")",
-            "public.ecr.aws": "$(json_escape "$(curl -I --max-time 5 -s -o /dev/null -w "%{http_code}" "https://public.ecr.aws/datadog/agent/manifests/latest")")"
-        },
         "host": {
             "hostname": "$(json_escape "$(uname -n)")",
             "os": "$(json_escape "${os}")",
@@ -449,6 +444,9 @@ function report_installer_telemetry() {
                         "version": "${install_script_version}",
                         "packages_to_install": "$(json_escape "${packages_to_install}")",
                         "packages_to_install_after_installer": "$(json_escape "${packages_to_install_after_installer}")"
+                        "network.gcr_io": "$(json_escape "$(curl -I --max-time 5 -s -o /dev/null -w "%{http_code}" "https://gcr.io/v2/datadoghq/installer-package/manifests/latest")")",
+                        "network.install_datadoghq_com": "$(json_escape "$(curl -I --max-time 5 -s -o /dev/null -w "%{http_code}" "https://install.datadoghq.com/scripts/install_script_agent7.sh")")",
+                        "network.public_ecr_aws": "$(json_escape "$(curl -I --max-time 5 -s -o /dev/null -w "%{http_code}" "https://public.ecr.aws/datadog/agent/manifests/latest")")"
                     },
                     "metrics": {
                         "_trace_root": 1,


### PR DESCRIPTION
This PR fixes the forwarding of the network metadata. We're hitting some issues with `.` that are interpreted in domain names. Replacing those by `_` to fix the issue.