### PR TITLE
[ACIX-322] Use registry.ddbuild.io for buildimages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,8 @@ stages:
 
 variables:
   AWS_MAX_ATTEMPTS: 5 # retry AWS operations 5 times if they fail on network errors
-  CI_IMAGE_AGENT_DEPLOY: v47046711-76471b8e
-  CI_IMAGE_DEB_X64: v47046711-76471b8e
+  CI_IMAGE_AGENT_DEPLOY: v47979770-a5a4cfd0
+  CI_IMAGE_DEB_X64: v47979770-a5a4cfd0
   S3_CP_CMD: aws s3 cp --only-show-errors --region us-east-1 --sse AES256
   TEST_INFRA_DEFINITIONS_BUILDIMAGES: 8aaa61cc1c42
   DEFAULT_MAJOR_VERSION: 7
@@ -37,7 +37,7 @@ default:
     - '[ ! -z "$TEST_PIPELINE_ID" ] && export TESTING_APT_REPO_VERSION="pipeline-${TEST_PIPELINE_ID}-a${MAJOR_VERSION}-x86_64 ${MAJOR_VERSION}"'
 
 generate-scripts:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$CI_IMAGE_DEB_X64
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:$CI_IMAGE_DEB_X64
   tags: [arch:amd64]
   stage: generate
   script:
@@ -56,7 +56,7 @@ generate-scripts:
 # Common fetching step to avoid having every e2e test job re-fetch everything over the net
 go_e2e_deps:
   stage: deps_fetch
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$CI_IMAGE_DEB_X64
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:$CI_IMAGE_DEB_X64
   tags: ["arch:amd64"]
   variables:
     KUBERNETES_CPU_REQUEST: 16
@@ -429,7 +429,7 @@ e2e:
           - --run TestUpgrade7Suite
 
 deploy:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$CI_IMAGE_AGENT_DEPLOY
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:$CI_IMAGE_AGENT_DEPLOY
   tags: ["arch:amd64"]
   stage: deploy
   dependencies: ["generate-scripts"]


### PR DESCRIPTION
Update to new image version. We can now pull from `registry.ddbuild.io`