### PR TITLE
fix noisy debug log

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -514,7 +514,7 @@ END
     then
         echo "Unable to send trace telemetry\n"
     fi
-    echo "$telemetry_trace" | $sudo_cmd tee /tmp/datadog-installer-trace.json
+    echo "$telemetry_trace" | $sudo_cmd tee /tmp/datadog-installer-trace.json > /dev/null
 }
 
 function _install_installer() {


### PR DESCRIPTION
`tee` writes not only to the file but also to stdout making the telemetry installation trace print

redirecting tee to /dev/null is a[ pattern already followed in install script ](https://github.com/DataDog/agent-linux-install-script/blob/main/install_script.sh.template#L1794)

This log was introduced by [mistake here
](https://github.com/DataDog/agent-linux-install-script/pull/289/files)

logs obtained after fix
```
Ign:1 https://apt.datadoghq.com stable InRelease
Hit:2 https://apt.datadoghq.com stable Release
Reading package lists...
  Installing package(s): datadog-signing-keys
 ```

logs before fix
```
gpg: key D3A80E30382E94DE: "Datadog, Inc <package@datadoghq.com>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
Ign:1 https://apt.datadoghq.com stable InRelease
Hit:2 https://apt.datadoghq.com stable Release
Reading package lists...
    {
        "api_version": "v2",
        "request_type": "traces",
        "tracer_time": 1730916610,
        "runtime_id": "8939883424964434389",
        "seq_id": 1,
        "origin": "linux-install-script",
        "host": {
            "hostname": "raphael-debian12",
            "os": "Debian",
            "distribution": "Debian",
            "architecture": "x86_64",
            "kernel_version": "#1 SMP PREEMPT_DYNAMIC Debian 6.1.106-3 (2024-08-26)",
            "kernel_name": "Linux",
            "kernel_release": "6.1.0-25-cloud-amd64"
        },
        "application": {
            "service_name": "datadog-linux-install-script",
            "service_version": "1.35.4",
            "language_name": "UNKNOWN",
            "language_version": "n/a",
            "tracer_version": "n/a"
        },
        "payload": {
            "traces": [[
                {
                    "service": "datadog-linux-install-script",
                    "name": "install_installer",
                    "resource": "install_installer",
                    "trace_id": 8939883424964434389,
                    "span_id": 8939883424964434389,
                    "parent_id": 0,
                    "start": 1730916608030412728,
                    "duration": 2958371849,
                    "error": 0,
                    "meta": {
                        "language": "shell",
                        "exit_code": 0,
                        "error.message": "W: --force-yes is deprecated, use one of the options starting with --allow instead.",
                        "version": "1.35.4",
                        "packages_to_install": "datadog-signing-keys",
                        "packages_to_install_after_installer": "datadog-signing-keys",
                        "network.gcr_io": "200",
                        "network.install_datadoghq_com_install_script": "200",
                        "network.install_datadoghq_com_index": "200",
                        "network.public_ecr_aws": "401",
                        "network.yum_datadoghq_com": "200",
                        "network.apt_datadoghq_com": "200"
                    },
                    "metrics": {
                        "_trace_root": 1,
                        "_top_level": 1,
                        "_dd.top_level": 1,
                        "_sampling_priority_v1": 2
                    }
                }
            ]]
        }
    }
  Installing package(s): datadog-signing-keys
```

