### PR TITLE
Tests to ensure that deb/rpm are not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ install_script_docker_injection.sh: install_script.sh.template
 		-e 's|INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER|Docker Injection|' \
 		-e 's|INSTALL_INFO_VERSION_PLACEHOLDER|_docker_injection|' \
 		-e 's|IS_LEGACY_SCRIPT_PLACEHOLDER||' \
-		-e 's|DD_APM_INSTRUMENTATION_ENABLED_DOCKER_PLACEHOLDER|DD_APM_INSTRUMENTATION_ENABLED="docker"|' \
+		-e 's|DD_APM_INSTRUMENTATION_ENABLED_DOCKER_PLACEHOLDER|export DD_APM_INSTRUMENTATION_ENABLED="docker"|' \
 		-e 's|APM_TELEMETRY_SAFE_AGENT_VERSION_OVERRIDE_PLACEHOLDER|safe_agent_version=noagent_autoinstrumentation|' \
 		-e 's|DEPRECATION_MESSAGE_PLACEHOLDER||' \
 		install_script.sh.template > $@

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -17,6 +17,8 @@ fi
 
 cp "$SCRIPT" /tmp/script.sh
 if [ "$DD_APM_INSTRUMENTATION_ENABLED" == "all" ] || [ "$DD_APM_INSTRUMENTATION_ENABLED" == "docker" ] || [ "$SCRIPT_FLAVOR" == "docker_injection" ]; then
+    # fake presence of docker for the installer
+    touch /usr/local/bin/docker && chmod +x /usr/local/bin/docker
     # fake presence of docker and make sure the script doesn't try to restart it
     mkdir /etc/docker
     sed -i "s|dd-container-install --no-agent-restart|dd-container-install --no-agent-restart --no-docker-reload|" /tmp/script.sh

--- a/test/localtest.sh
+++ b/test/localtest.sh
@@ -166,23 +166,13 @@ if [ -n "${DD_SYSTEM_PROBE_ENSURE_CONFIG}" ]; then
 fi
 
 if [ -n "$DD_APM_INSTRUMENTATION_ENABLED" ] || [ "${SCRIPT_FLAVOR}" == "docker_injection" ]; then
-  if [[ "$OS_TYPE" == "ubuntu" ]]; then
-      test -d /opt/datadog-packages/datadog-apm-inject/stable || debsums -c datadog-apm-inject
-      test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable || debsums -c datadog-apm-library-dotnet
-      test -d /opt/datadog-packages/datadog-apm-library-java/stable || debsums -c datadog-apm-library-java
-      test -d /opt/datadog-packages/datadog-apm-library-js/stable || debsums -c datadog-apm-library-js
-      test -d /opt/datadog-packages/datadog-apm-library-python/stable || debsums -c datadog-apm-library-python
-      test -d /opt/datadog-packages/datadog-apm-library-ruby/stable || debsums -c datadog-apm-library-ruby
-      echo "[OK] Inject libraries installed"
-  else
-      test -d /opt/datadog-packages/datadog-apm-inject/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-inject
-      test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
-      test -d /opt/datadog-packages/datadog-apm-library-java/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
-      test -d /opt/datadog-packages/datadog-apm-library-js/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
-      test -d /opt/datadog-packages/datadog-apm-library-python/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
-      test -d /opt/datadog-packages/datadog-apm-library-ruby/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
-      echo "[OK] Inject libraries installed"
-  fi
+  test -d /opt/datadog-packages/datadog-apm-inject/stable
+  test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable
+  test -d /opt/datadog-packages/datadog-apm-library-java/stable
+  test -d /opt/datadog-packages/datadog-apm-library-js/stable
+  test -d /opt/datadog-packages/datadog-apm-library-python/stable
+  test -d /opt/datadog-packages/datadog-apm-library-ruby/stable
+  echo "[OK] Inject libraries installed"
 
   if [ "$DD_APM_INSTRUMENTATION_ENABLED" == "all" ] || [ "$DD_APM_INSTRUMENTATION_ENABLED" == "host" ]; then
     if [ -f "/etc/ld.so.preload" ]; then
@@ -205,21 +195,12 @@ else
 fi
 
 if [ -n "$DD_APM_INSTRUMENTATION_LANGUAGES" ]; then
-  if [[ "$OS_TYPE" == "ubuntu" ]]; then
-    test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable || debsums -c datadog-apm-library-dotnet
-    test -d /opt/datadog-packages/datadog-apm-library-java/stable || debsums -c datadog-apm-library-java
-    test -d /opt/datadog-packages/datadog-apm-library-js/stable || debsums -c datadog-apm-library-js
-    test -d /opt/datadog-packages/datadog-apm-library-python/stable || debsums -c datadog-apm-library-python
-    test -d /opt/datadog-packages/datadog-apm-library-ruby/stable || debsums -c datadog-apm-library-ruby
-    echo "[OK] Inject libraries installed"
-  else
-    test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-dotnet
-    test -d /opt/datadog-packages/datadog-apm-library-java/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-java
-    test -d /opt/datadog-packages/datadog-apm-library-js/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-js
-    test -d /opt/datadog-packages/datadog-apm-library-python/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-python
-    test -d /opt/datadog-packages/datadog-apm-library-ruby/stable || rpm --verify --nomode --nouser --nogroup datadog-apm-library-ruby
-    echo "[OK] Inject libraries installed"
-  fi
+  test -d /opt/datadog-packages/datadog-apm-library-dotnet/stable
+  test -d /opt/datadog-packages/datadog-apm-library-java/stable
+  test -d /opt/datadog-packages/datadog-apm-library-js/stable
+  test -d /opt/datadog-packages/datadog-apm-library-python/stable
+  test -d /opt/datadog-packages/datadog-apm-library-ruby/stable
+  echo "[OK] Inject libraries installed"
 fi
 
 exit ${RESULT}


### PR DESCRIPTION
The test suite `install_script_docker_injection.sh` was failing as DD_APM_INSTRUMENTATION_ENABLED="docker" is expected to be propagated, yet the template just sets it a local var. Making datadog-installer miss the env

It's not a scenario expected in customer environments as setting `DD_APM_INSTRUMENTATION_ENABLED="docker"` is always documented and we document the general `install_script.sh`

I'll discard `install_script_docker_injection.sh` after next release as its not supported for the GA. Making sure first with another release that the env is properly set