### PR TITLE
[ASCII-2593] Add datadog-fips-agent to the linux install script hash as viable flavor

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -286,6 +286,9 @@ function getMapData() {
              "datadog-fips-proxy")
                 DATA="Datadog FIPS Proxy"
                 ;;
+             "datadog-fips-agent")
+                DATA="Datadog FIPS Agent"
+                ;;
              "datadog-heroku-agent")
                 DATA="Datadog Heroku Agent"
                 ;;


### PR DESCRIPTION
We haven't published a public package of the fips-enabled flavor of the datadog agent yet but we need to add it as an option in the install script to allow the e2e test framework to run against it.