### PR TITLE
[bug] Fix exit condition if nice_flavor is unknown

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -752,7 +752,7 @@ fi
 
 nice_flavor=$(getMapData flavor_to_readable "$agent_flavor")
 
-if [ -z "$nice_flavor" ]; then
+if [ "$nice_flavor" = "Unknown" ]; then
     ERROR_MESSAGE="Unknown DD_AGENT_FLAVOR \"$agent_flavor\""
     ERROR_CODE=$INVALID_PARAMETERS_CODE
     echo -e "\033[33m$ERROR_MESSAGE\033[0m"


### PR DESCRIPTION
https://github.com/DataDog/agent-linux-install-script/blob/c5be00b265e2e7e4646b07161ad955dba729409b/install_script.sh.template#L273-L301
-> When encountering a key not in the mapping, we default to `Unknown`, so we can never hit the exit block which looks for an empty string: https://github.com/DataDog/agent-linux-install-script/blob/c5be00b265e2e7e4646b07161ad955dba729409b/install_script.sh.template#L755-L762

PR introducing the `Unknown` entry: https://github.com/DataDog/agent-linux-install-script/pull/51/files#diff-79ac74a50e14d4fa9c80b1daba8bd5cc182f4b6c2a2b3951c0caa4fbc78f6f73. Previously, the hash did not have any defaults, so `nice_flavor` would end up empty:
```shell
flavor_to_readable=(
    ["datadog-agent"]="Datadog Agent"
    ["datadog-iot-agent"]="Datadog IoT Agent"
    ["datadog-dogstatsd"]="Datadog Dogstatsd"
    ["datadog-heroku-agent"]="Datadog Heroku Agent"
)
nice_flavor=${flavor_to_readable[$agent_flavor]}

if [ -z "$nice_flavor" ]; then
    echo -e "\033[33mUnknown DD_AGENT_FLAVOR \"$agent_flavor\"\033[0m"
    fallback_msg
    exit 1;
fi
```