### PR TITLE
Add option to enable Service Discovery

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -367,6 +367,7 @@ e2e:
           - --run TestInstallSuite
           - --run TestUpgrade6Suite
           - --run TestUpgrade7Suite
+          - --run TestInstallDiscoverySuite
           - --run TestInstallMaximalAndRetrySuite
           - --run TestInstallSecurityAgentSuite
           - --run TestInstallSystemProbeSuite

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The install script allows installation of different flavors of the Agent binarie
 |`DD_SYSTEM_PROBE_ENSURE_CONFIG`|Create the system probe configuration file from a template if it does not already exist.|
 |`DD_RUNTIME_SECURITY_CONFIG_ENABLED`|If set to `true`, ensure creation of security Agent and system probe configuration file (if they don't already exist), and enable Cloud Workload Security (CWS).|
 |`DD_COMPLIANCE_CONFIG_ENABLED`|If set to `true`, ensures the creation of a security Agent configuration file if one doesn't already exist, and enables Cloud Security Posture Management (CSPM).|
+|`DD_DISCOVERY_ENABLED`|If set to `true`, and a system probe configuration file does not already exist, creates a system probe configuration file and enables Service Discovery.
 |`DD_INSTALL_ONLY`|Set to any value to prevent starting the Agent after installation.|
 |`DD_NO_AGENT_INSTALL`|Do not install the Agent. Instead, installs package signature keys and creates configuration files if they don't already exist. Automatically set to `true` when `DD_APM_INSTRUMENTATION_ENABLED=docker`.|
 

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1610,7 +1610,7 @@ function update_discovery(){
   $sudo_cmd cp "$config_file" "${config_file}.orig"
   $sudo_cmd sh -c "exec cat - '${config_file}.orig' > '$config_file'" <<EOF
 discovery:
-    enabled: true
+  enabled: true
 EOF
 }
 function manage_security_config(){

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1602,20 +1602,24 @@ apm_config:
       enabled: true
 EOF
 }
-function manage_security_and_system_probe_config(){
+function manage_security_config(){
   local sudo_cmd="$1"
   local security_config_file="$2"
-  local probe_config_file="$3"
-  local enable_security="$4"
-  local enable_compliance="$5"
+  local enable_security="$3"
+  local enable_compliance="$4"
   if [ "$enable_security" == "true" ] || [ "$enable_compliance" == "true" ]; then
     if ensure_config_file_exists "$sudo_cmd" "$security_config_file" "root"; then
       update_security_and_or_compliance "$sudo_cmd" "$security_config_file" "$enable_security" "$enable_compliance"
     fi
-    if [ "$enable_security" == "true" ]; then
-      if ensure_config_file_exists "$sudo_cmd" "$probe_config_file" "root"; then
-        update_security_and_or_compliance "$sudo_cmd" "$probe_config_file" "$enable_security" "false"
-      fi
+  fi
+}
+function manage_system_probe_config(){
+  local sudo_cmd="$1"
+  local probe_config_file="$2"
+  local enable_security="$3"
+  if [ "$enable_security" == "true" ]; then
+    if ensure_config_file_exists "$sudo_cmd" "$probe_config_file" "root"; then
+      update_security_and_or_compliance "$sudo_cmd" "$probe_config_file" "$enable_security" "false"
     fi
   fi
 }
@@ -1691,7 +1695,8 @@ elif [ ! "$no_agent" ]; then
     update_hosttags "$sudo_cmd" "$host_tags" "$config_file"
     update_env "$sudo_cmd" "$dd_env" "$config_file"
   fi
-  manage_security_and_system_probe_config "$sudo_cmd" "$security_agent_config_file" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
+  manage_security_config "$sudo_cmd" "$security_agent_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
+  manage_system_probe_config "$sudo_cmd" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED"
 fi
 
 manage_client_libraries_security_config "$sudo_cmd" "$environment_file" "$DD_APPSEC_ENABLED" "$DD_IAST_ENABLED" "$DD_APPSEC_SCA_ENABLED"

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1602,6 +1602,17 @@ apm_config:
       enabled: true
 EOF
 }
+function update_discovery(){
+  local sudo_cmd="$1"
+  local config_file="$2"
+
+  printf "\033[34m\n* Setting $nice_flavor configuration to enable Service Discovery: $config_file\n\033[0m\n"
+  $sudo_cmd cp "$config_file" "${config_file}.orig"
+  $sudo_cmd sh -c "exec cat - '${config_file}.orig' > '$config_file'" <<EOF
+discovery:
+    enabled: true
+EOF
+}
 function manage_security_config(){
   local sudo_cmd="$1"
   local security_config_file="$2"
@@ -1617,9 +1628,13 @@ function manage_system_probe_config(){
   local sudo_cmd="$1"
   local probe_config_file="$2"
   local enable_security="$3"
-  if [ "$enable_security" == "true" ]; then
+  local enable_discovery="$4"
+  if [ "$enable_security" == "true" ] || [ "$enable_discovery" == "true" ]; then
     if ensure_config_file_exists "$sudo_cmd" "$probe_config_file" "root"; then
       update_security_and_or_compliance "$sudo_cmd" "$probe_config_file" "$enable_security" "false"
+      if [ "$enable_discovery" == "true" ]; then
+        update_discovery "$sudo_cmd" "$probe_config_file"
+      fi
     fi
   fi
 }
@@ -1696,7 +1711,7 @@ elif [ ! "$no_agent" ]; then
     update_env "$sudo_cmd" "$dd_env" "$config_file"
   fi
   manage_security_config "$sudo_cmd" "$security_agent_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
-  manage_system_probe_config "$sudo_cmd" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED"
+  manage_system_probe_config "$sudo_cmd" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_DISCOVERY_ENABLED"
 fi
 
 manage_client_libraries_security_config "$sudo_cmd" "$environment_file" "$DD_APPSEC_ENABLED" "$DD_IAST_ENABLED" "$DD_APPSEC_SCA_ENABLED"

--- a/test/e2e/install_discovery_test.go
+++ b/test/e2e/install_discovery_test.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/stretchr/testify/assert"
+)
+
+type installDiscoveryTestSuite struct {
+	linuxInstallerTestSuite
+}
+
+func TestInstallDiscoverySuite(t *testing.T) {
+	if flavor != agentFlavorDatadogAgent {
+		t.Skip("discovery test supports only datadog-agent flavor")
+	}
+	stackName := fmt.Sprintf("install-discovery-%s-%s-%s", flavor, platform, getenv("CI_PIPELINE_ID", "dev"))
+	t.Run(stackName, func(t *testing.T) {
+		t.Logf("We will install with system-probe %s with install script on %s", flavor, platform)
+		testSuite := &installDiscoveryTestSuite{}
+		e2e.Run(t,
+			testSuite,
+			e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(awshost.WithEC2InstanceOptions(getEC2Options(t)...))),
+			e2e.WithStackName(stackName),
+		)
+	})
+}
+
+func (s *installDiscoveryTestSuite) TestInstallSystemProbe() {
+	s.InstallAgent(7, "DD_DISCOVERY_ENABLED=true DD_SITE=\"datadoghq.com\"", "Install latest Agent 7")
+
+	s.assertInstallScript()
+
+	s.addExtraIntegration()
+
+	s.uninstall()
+
+	s.assertUninstall()
+
+	s.purge()
+
+	s.assertPurge()
+}
+
+func (s *installDiscoveryTestSuite) assertInstallScript() {
+	s.linuxInstallerTestSuite.assertInstallScript(true)
+	t := s.T()
+	vm := s.Env().RemoteHost
+	t.Log("Assert system probe config is created and security-agent is not created")
+	assertFileExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
+	assertFileNotExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, securityAgentConfigFileName))
+
+	systemProbeConfig := unmarshalConfigFile(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
+	assert.NotContains(t, systemProbeConfig, "runtime_security_config")
+	assert.Equal(t, true, systemProbeConfig["discovery"].(map[any]any)["enabled"])
+}
+
+func (s *installDiscoveryTestSuite) assertUninstall() {
+	s.linuxInstallerTestSuite.assertUninstall()
+	t := s.T()
+	vm := s.Env().RemoteHost
+	t.Log("Assert system probe is there after uninstall")
+	assertFileExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
+}
+
+func (s *installDiscoveryTestSuite) assertPurge() {
+	if s.shouldSkipPurge() {
+		return
+	}
+	s.linuxInstallerTestSuite.assertPurge()
+	t := s.T()
+	vm := s.Env().RemoteHost
+	t.Log("Assert system probe is removed after purge")
+	assertFileNotExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
+}

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -202,7 +202,7 @@ testSecurityConfigNoCreation() {
 }
 testSecurityConfigPreventOnBoth() {
   sudo cp ${security_agent_config_file}.example $security_agent_config_file
-  manage_security_and_system_probe_config "sudo" $security_agent_config_file true true
+  manage_security_config "sudo" $security_agent_config_file true true
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 1 $?
   sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
@@ -210,7 +210,7 @@ testSecurityConfigPreventOnBoth() {
 }
 testSecurityConfigComplianceOnSecurity(){
   sudo rm $security_agent_config_file 2> /dev/null
-  manage_security_and_system_probe_config "sudo" $security_agent_config_file false true
+  manage_security_config "sudo" $security_agent_config_file false true
   yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
   assertEquals 0 $?
   sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
@@ -218,7 +218,7 @@ testSecurityConfigComplianceOnSecurity(){
 }
 testSecurityConfigSecOnBoth(){
   sudo rm $security_agent_config_file 2> /dev/null
-  manage_security_and_system_probe_config "sudo" $security_agent_config_file true false
+  manage_security_config "sudo" $security_agent_config_file true false
   yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
   assertEquals 0 $?
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
@@ -226,7 +226,7 @@ testSecurityConfigSecOnBoth(){
 }
 testSecurityConfigFullConfig(){
   sudo rm $security_agent_config_file 2> /dev/null
-  manage_security_and_system_probe_config "sudo" $security_agent_config_file true true
+  manage_security_config "sudo" $security_agent_config_file true true
   yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
   assertEquals 0 $?
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -193,61 +193,70 @@ testSecurityAndComplianceDisabled() {
   assertEquals 1 $?
 }
 
-### Manage security and probe config files
-testNoCreation() {
-  sudo rm $security_agent_config_file $system_probe_config_file 2> /dev/null
-  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file false false
+### Manage security config files
+testSecurityConfigNoCreation() {
+  sudo rm $security_agent_config_file 2> /dev/null
+  manage_security_config "sudo" $security_agent_config_file false false
   sudo test -e $security_agent_config_file
   assertEquals 1 $?
-  sudo test -e $system_probe_config_file
-  assertEquals 1 $?
 }
-testPreventOnBoth() {
+testSecurityConfigPreventOnBoth() {
   sudo cp ${security_agent_config_file}.example $security_agent_config_file
-  sudo cp ${system_probe_config_file}.example $system_probe_config_file
-  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file true true
+  manage_security_and_system_probe_config "sudo" $security_agent_config_file true true
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 1 $?
   sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 1 $?
 }
-testComplianceOnSecurity(){
-  sudo rm $security_agent_config_file $system_probe_config_file 2> /dev/null
-  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file false true
+testSecurityConfigComplianceOnSecurity(){
+  sudo rm $security_agent_config_file 2> /dev/null
+  manage_security_and_system_probe_config "sudo" $security_agent_config_file false true
   yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
   assertEquals 0 $?
   sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
+}
+testSecurityConfigSecOnBoth(){
+  sudo rm $security_agent_config_file 2> /dev/null
+  manage_security_and_system_probe_config "sudo" $security_agent_config_file true false
+  yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
+  assertEquals 0 $?
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+}
+testSecurityConfigFullConfig(){
+  sudo rm $security_agent_config_file 2> /dev/null
+  manage_security_and_system_probe_config "sudo" $security_agent_config_file true true
+  yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
+  assertEquals 0 $?
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+  sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+}
+
+### Manage system probe config files
+testSystemProbeConfigNoCreation() {
+  sudo rm $system_probe_config_file 2> /dev/null
+  manage_system_probe_config "sudo" $system_probe_config_file false false
   sudo test -e $system_probe_config_file
   assertEquals 1 $?
 }
-testSecOnBoth(){
-  sudo rm $security_agent_config_file $system_probe_config_file 2> /dev/null
-  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file true false
-  yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
-  assertEquals 0 $?
+testSystemProbeConfigSecOnBoth(){
+  sudo rm $system_probe_config_file 2> /dev/null
+  manage_system_probe_config "sudo" $system_probe_config_file true false
   yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
-  assertEquals 0 $?
-  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
 }
-testFullConfig(){
-  sudo rm $security_agent_config_file $system_probe_config_file 2> /dev/null
-  manage_security_and_system_probe_config "sudo" $security_agent_config_file $system_probe_config_file true true
-  yamllint -c "$yaml_config" --no-warnings $security_agent_config_file
-  assertEquals 0 $?
+testSystemProbeConfigFullConfig(){
+  sudo rm $system_probe_config_file 2> /dev/null
+  manage_system_probe_config "sudo" $system_probe_config_file true true
   yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
-  assertEquals 0 $?
-  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
-  assertEquals 0 $?
-  sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
-  sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
-  assertEquals 1 $?
 }
 
 ### Manage client libraries security config

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -223,6 +223,8 @@ testSecurityConfigSecOnBoth(){
   assertEquals 0 $?
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
+  sudo sed -e '0,/^compliance_config/d' -e '/^[^ ]/,$d' $security_agent_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 1 $?
 }
 testSecurityConfigFullConfig(){
   sudo rm $security_agent_config_file 2> /dev/null
@@ -242,12 +244,24 @@ testSystemProbeConfigNoCreation() {
   sudo test -e $system_probe_config_file
   assertEquals 1 $?
 }
-testSystemProbeConfigSecOnBoth(){
+testSystemProbeConfigSecOn(){
   sudo rm $system_probe_config_file 2> /dev/null
   manage_system_probe_config "sudo" $system_probe_config_file true false
   yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
   assertEquals 0 $?
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+  sudo sed -e '0,/^discovery/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 1 $?
+}
+testSystemProbeConfigDiscoveryOn(){
+  sudo rm $system_probe_config_file 2> /dev/null
+  manage_system_probe_config "sudo" $system_probe_config_file false true
+  yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
+  assertEquals 0 $?
+  sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 1 $?
+  sudo sed -e '0,/^discovery/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
 }
 testSystemProbeConfigFullConfig(){
@@ -256,6 +270,8 @@ testSystemProbeConfigFullConfig(){
   yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
   assertEquals 0 $?
   sudo sed -e '0,/^runtime_security_config/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
+  assertEquals 0 $?
+  sudo sed -e '0,/^discovery/d' -e '/^[^ ]/,$d' $system_probe_config_file | grep -v "#" | grep -q "enabled: true"
   assertEquals 0 $?
 }
 


### PR DESCRIPTION
Add support for enabling Service Discovery during installation by setting the `DD_DISCOVERY_ENABLED=true` environment variable. Note that Service Discovery needs system probe, so that configuration file is updated.

https://datadoghq.atlassian.net/browse/DSCVR-79

## Testing

Unit tests and e2e tests have been added.

Manual test can be done with something like this:

On an EC2 instance or Linux VM:

```
make
DD_API_KEY=123 DD_SITE="datadoghq.com" DD_DISCOVERY_ENABLED=true ./install_script_agent7.sh
``` 

Once installation has finished, wait for the agent to start and then run:

```
sudo curl --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/discovery/debug --fail-with-body
```

If the command does not fail, then Service Discovery has been enabled.