### PR TITLE
[e2e] Correct example command in README

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -19,7 +19,9 @@ Use `go test` to run tests locally, from a shell wrapped in a valid aws session.
 ### Example: run install test, flavor datadog-agent, platform Amazon 2023
 
 ```shell
-cd test/e2e && go test -timeout 0s . -v --run TestInstallSuite --flavor datadog-agent --platform Amazon_Linux_2023
+make
+export DD_API_KEY=...
+cd test/e2e && go test -timeout 0s . -v --run TestInstallSuite --flavor datadog-agent --platform Amazon_Linux_2023 -scriptPath=$PWD/../../
 ```
 
 ## Run on CI


### PR DESCRIPTION
The example command in the README to run the e2e tests locally results in failing tests since it (1) doesn't specify the path to copy the scripts (2) doesn't indicate that the scripts have to be built and (3) doesn't have the API key set; provide a more complete example.