### PR TITLE
set environment variables for error tracking standalone

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1672,6 +1672,18 @@ function manage_client_libraries_profiling_config(){
     fi
   fi
 }
+function manage_error_tracking_standalone_config(){
+  local sudo_cmd="$1"
+  local etc_environment="$2"
+  if [ "$error_tracking_standalone" == "true" ]; then
+    printf "\033[34m\n* Setting system environment to use Error Tracking backend: $etc_environment\n\033[0m\n"
+    set_in_env_file "$sudo_cmd" "$etc_environment" DD_APM_ERROR_TRACKING_STANDALONE_ENABLED "true"
+    set_in_env_file "$sudo_cmd" "$etc_environment" DD_CORE_AGENT_ENABLED "false"
+  elif [ "$error_tracking_standalone" == "false" ]; then
+    set_in_env_file "$sudo_cmd" "$etc_environment" DD_APM_ERROR_TRACKING_STANDALONE_ENABLED "false"
+    set_in_env_file "$sudo_cmd" "$etc_environment" DD_CORE_AGENT_ENABLED "true"
+  fi
+}
 # "Main" configuration update
 if [ -e "$config_file" ] && [ -z "$upgrade" ]; then
   printf "\033[34m\n* Keeping old $config_file configuration file\n\033[0m\n"
@@ -1699,6 +1711,7 @@ manage_client_libraries_profiling_config "$sudo_cmd" "$environment_file" "$DD_PR
 if [ -e "$(dirname $dd_environment_file)" ]; then
   manage_infrastructure_vulnerabilities_config "$sudo_cmd" "$dd_environment_file" "$DD_SBOM_CONTAINER_IMAGE_ENABLED" "$DD_SBOM_HOST_ENABLED"
 fi
+manage_error_tracking_standalone_config "$sudo_cmd" "$environment_file"
 
 update_fleet_automation "$sudo_cmd" "$remote_updates" "$remote_policies" "$fips_mode" "$site" "$config_file"
 update_installer_registry "$sudo_cmd" "$installer_registry_url" "$installer_registry_auth" "$config_file"

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -19,6 +19,7 @@ import (
 	componentsos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 
+	envparse "github.com/hashicorp/go-envparse"
 	version "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,7 @@ var (
 		agentFlavorDatadogDogstatsd: "dogstatsd.yaml",
 		agentFlavorDatadogIOTAgent:  "datadog.yaml",
 	}
+	envFile            = "/etc/environment"
 	osConfigByPlatform = map[string]osConfig{
 		"Debian_11":         {osDescriptor: componentsos.NewDescriptor(componentsos.Debian, "11")},
 		"Ubuntu_22_04":      {osDescriptor: componentsos.UbuntuDefault},
@@ -357,5 +359,14 @@ func unmarshalConfigFile(t *testing.T, vm *components.RemoteHost, configFilePath
 	config := map[string]any{}
 	err := yaml.Unmarshal([]byte(configContent), &config)
 	require.NoError(t, err, fmt.Sprintf("unexpected error on yaml parse %v, raw content:\n%s\n\n", err, configContent))
+	return config
+}
+
+func unmarshallEnvFile(t *testing.T, vm *components.RemoteHost, envFilePath string) map[string]string {
+	t.Helper()
+	configContent := vm.MustExecute(fmt.Sprintf("sudo cat /%s", envFilePath))
+	reader := strings.NewReader(configContent)
+	config, err := envparse.Parse(reader)
+	require.NoError(t, err, fmt.Sprintf("unexpected error on env parse %v, raw content:\n%s\n\n", err, configContent))
 	return config
 }

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.8
 require (
 	github.com/DataDog/datadog-agent/test/new-e2e v0.56.0-devel.0.20240619155906-9b99ef437a92
 	github.com/DataDog/test-infra-definitions v0.0.0-20241121181216-eefd2de87300
+	github.com/hashicorp/go-envparse v0.1.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -206,6 +206,8 @@ github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-envparse v0.1.0 h1:bE++6bhIsNCPLvgDZkYqo3nA+/PFI51pkrHdmPSDFPY=
+github.com/hashicorp/go-envparse v0.1.0/go.mod h1:OHheN1GoygLlAkTlXLXvAdnXdZxy8JUweQ1rAXx1xnc=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=

--- a/test/e2e/install_error_tracking_standalone_test.go
+++ b/test/e2e/install_error_tracking_standalone_test.go
@@ -52,7 +52,7 @@ func (s *installErrorTrackingStandaloneTestSuite) assertInstallErrorTrackingStan
 	s.assertInstallScript(true)
 
 	t.Log("assert install output contains expected lines")
-	assert.Contains(t, installCommandOutput, "* Setting Datadog Agent configuration to use configuration to use Error Tracking backend: /etc/datadog-agent/datadog.yaml", "Missing installer log line for Error Tracking backend")
+	assert.Contains(t, installCommandOutput, "* Setting Datadog Agent configuration to use Error Tracking backend: /etc/datadog-agent/datadog.yaml", "Missing installer log line for Error Tracking backend")
 
 	t.Log("assert agent configuration contains expected properties")
 	config := unmarshalConfigFile(t, vm, fmt.Sprintf("etc/%s/%s", s.baseName, s.configFile))
@@ -64,4 +64,11 @@ func (s *installErrorTrackingStandaloneTestSuite) assertInstallErrorTrackingStan
 	etStandaloneConfig, ok := apmConfig["error_tracking_standalone"].(map[any]any)
 	assert.True(t, ok, fmt.Sprintf("failed parsing apmConfig[error_tracking_standalone] to map \n%v\n\n", apmConfig["error_tracking_standalone"]))
 	assert.Equal(t, true, etStandaloneConfig["enabled"], fmt.Sprintf("apm_config.error_tracking_standalone.enabled should be true, content:\n%v\n\n", etStandaloneConfig))
+
+	t.Log("assert agent configuration contains expected properties")
+	env := unmarshallEnvFile(t, vm, envFile)
+	assert.Contains(t, env, "DD_APM_ERROR_TRACKING_STANDALONE_ENABLED")
+	assert.Contains(t, env, "DD_CORE_AGENT_ENABLED")
+	assert.Equal(t, "true", env["DD_APM_ERROR_TRACKING_STANDALONE_ENABLED"])
+	assert.Equal(t, "false", env["DD_CORE_AGENT_ENABLED"])
 }


### PR DESCRIPTION
Moving forward we'd like to make use of the `DD_CORE_AGENT_ENABLED` flag, which is why it's being written to the `/etc/environment`

This PR also fixes the error tracking standalone e2e test not being executed in the CI