### PR TITLE
upgrade(installer): Use installer install script when DD_REMOTE_UPDATES=true

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -504,7 +504,7 @@ function _install_installer() {
         return 0
     fi
     command_prefix="${sudo_cmd:+$sudo_cmd -E}"
-    $command_prefix sh -c "DD_API_KEY=\"${apikey}\" DD_SITE=\"${site}\" DD_REMOTE_POLICIES=\"${remote_policies}\" DD_REMOTE_UPDATES=\"${remote_updates}\" DATADOG_TRACE_ID=\"${trace_id}\" DATADOG_PARENT_ID=\"${trace_id}\" /usr/bin/datadog-bootstrap bootstrap"
+    $command_prefix sh -c "DD_API_KEY=\"${apikey}\" DD_SITE=\"${site}\" DATADOG_TRACE_ID=\"${trace_id}\" DATADOG_PARENT_ID=\"${trace_id}\" /usr/bin/datadog-bootstrap bootstrap"
     return $?
 }
 
@@ -589,6 +589,47 @@ function install_installer() {
     fi
     return "$exit_status"
 }
+
+# install_managed_agent installs the agent with Fleet Automation's agent management (preview feature).
+function install_managed_agent() {
+  echo "Installing the Datadog Agent with Fleet Management"
+  installer_domain=${DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE:-$([[ "$DD_SITE" == "datad0g.com" ]] && echo "install.datad0g.com" || echo "install.datadoghq.com")}
+  installer_url="https://${installer_domain}/scripts/install.sh"
+  if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
+    installer_url="https://${installer_domain}/scripts/install-7.${DD_AGENT_MINOR_VERSION}.sh"
+  fi
+  if command -v curl >/dev/null; then
+    http_code=$(curl -ILsf --retry 3 -w "%{http_code}" -o /dev/null "$installer_url" || true)
+    if [ "$http_code" -ne "200" ]; then
+      echo "Error: Unable to download the installer script from $installer_url. HTTP status code: $http_code"
+      exit 1
+    fi
+    if ! bash <(curl -L -s -f --retry 3 "$installer_url"); then
+      exit 1
+    fi
+  elif command -v wget >/dev/null; then
+    http_code=$(wget -q --tries=3 --server-response --spider --tries=3 "$installer_url" 2>&1 | awk '/^  HTTP/{print $2}' | tail -n1 | tr -d '\n')
+    if [ "$http_code" -ne 200 ]; then
+      echo "Error: Unable to download the installer script from $installer_url. HTTP status code: $http_code"
+      exit 1
+    fi
+    if ! bash <(wget -q --tries=3 -O - "$installer_url"); then
+      exit 1
+    fi
+  else
+    echo "Error: Curl or wget is required to install the agent with Fleet Management."
+    exit 1
+  fi
+  exit 0
+}
+
+##
+# INSTALLER INSTALL SCRIPT HATCH
+# If DD_REMOTE_UPDATES is set, we will use the installer script to install the agent
+##
+if [ -n "$DD_REMOTE_UPDATES" ]; then
+  install_managed_agent
+fi
 
 echo -e "\033[34m\n* Datadog INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER install script v${install_script_version}\n\033[0m"
 
@@ -676,15 +717,6 @@ if [ -n "$DD_INSTALLER" ]; then
     datadog_installer=true
 fi
 
-remote_updates=
-if [ -n "$DD_REMOTE_UPDATES" ]; then
-    remote_updates=$DD_REMOTE_UPDATES
-fi
-
-remote_policies=
-if [ -n "$DD_REMOTE_POLICIES" ]; then
-    remote_policies=$DD_REMOTE_POLICIES
-fi
 
 installer_registry_url=
 if [ -n "$DD_INSTALLER_REGISTRY_URL" ]; then
@@ -1518,39 +1550,6 @@ function update_env(){
     $sudo_cmd sh -c "sed -i 's|^# env:.*|env: $dd_env|' $config_file"
   fi
 }
-function update_fleet_automation(){
-  local sudo_cmd="$1"
-  local remote_updates="$2"
-  local remote_policies="$3"
-  local fips_mode="$4"
-  local site="$5"
-  local config_file="$6"
-
-  if [ -n "$fips_mode" ]; then
-    printf "\033[31mFleet automation is not supported in FIPS mode.\033[0m\n"
-    return 0
-  elif [ "$site" == "ddog-gov.com" ]; then
-    printf "\033[31mFleet automation is not supported with the Datadog Gov site.\033[0m\n"
-    return 0
-  fi
-
-  if [ -n "$remote_updates" ]; then
-    printf "\033[34m\n* Adding your DD_REMOTE_UPDATES to the $nice_flavor configuration: $config_file\n\033[0m\n"
-    if ! $sudo_cmd grep -q "^remote_updates:" "$config_file"; then
-        $sudo_cmd sh -c "echo 'remote_updates: $remote_updates' >> $config_file"
-    else
-        $sudo_cmd sh -c "sed -i 's/^remote_updates:.*/remote_updates: $remote_updates/' $config_file"
-    fi
-  fi
-  if [ -n "$remote_policies" ]; then
-    printf "\033[34m\n* Adding your DD_REMOTE_POLICIES to the $nice_flavor configuration: $config_file\n\033[0m\n"
-    if ! $sudo_cmd grep -q "^remote_policies:" "$config_file"; then
-        $sudo_cmd sh -c "echo 'remote_policies: $remote_policies' >> $config_file"
-    else
-        $sudo_cmd sh -c "sed -i 's/^remote_policies:.*/remote_policies: $remote_policies/' $config_file"
-    fi
-  fi
-}
 function update_installer_registry(){
   local sudo_cmd="$1"
   local registry_url="$2"
@@ -1733,7 +1732,6 @@ if [ -e "$(dirname $dd_environment_file)" ]; then
 fi
 manage_error_tracking_standalone_config "$sudo_cmd" "$environment_file"
 
-update_fleet_automation "$sudo_cmd" "$remote_updates" "$remote_policies" "$fips_mode" "$site" "$config_file"
 update_installer_registry "$sudo_cmd" "$installer_registry_url" "$installer_registry_auth" "$config_file"
 
 if [ ! "$no_agent" ]; then

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -592,7 +592,7 @@ function install_installer() {
 
 # install_managed_agent installs the agent with Fleet Automation's agent management (preview feature).
 function install_managed_agent() {
-  echo "Installing the Datadog Agent with Fleet Management"
+  echo "Installing the Datadog Agent with Remote Agent Management"
   installer_domain=${DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE:-$([[ "$DD_SITE" == "datad0g.com" ]] && echo "install.datad0g.com" || echo "install.datadoghq.com")}
   installer_url="https://${installer_domain}/scripts/install.sh"
   if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
@@ -617,7 +617,7 @@ function install_managed_agent() {
       exit 1
     fi
   else
-    echo "Error: Curl or wget is required to install the agent with Fleet Management."
+    echo "Error: Curl or wget is required to install the agent with Remote Agent Management."
     exit 1
   fi
   exit 0

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -81,7 +81,7 @@ func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalle
 func (s *installUpdaterTestSuite) TestInstallWithRemoteUpdates() {
 	t := s.T()
 	vm := s.Env().RemoteHost
-	cmd := fmt.Sprintf("DD_REMOTE_UPDATES=true DD_API_KEY=%s DD_SITE=\"datad0g.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
+	cmd := fmt.Sprintf("DD_AGENT_MINOR_VERSION=66.0~devel.git.413.5e29099 DD_REMOTE_UPDATES=true DD_API_KEY=%s DD_SITE=\"datad0g.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
 	output := vm.MustExecute(cmd)
 	t.Log(output)
 	defer s.purge()

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -78,10 +78,23 @@ func (s *installUpdaterTestSuite) TestPackagesInstalledByInstallerAreNotInstalle
 	s.assertPackageNotInstalledByPackageManager("datadog-apm-library-python")
 }
 
+func (s *installUpdaterTestSuite) TestInstallWithRemoteUpdates() {
+	t := s.T()
+	vm := s.Env().RemoteHost
+	cmd := fmt.Sprintf("DD_REMOTE_UPDATES=true DD_API_KEY=%s DD_SITE=\"datad0g.com\" bash -c \"$(cat scripts/install_script_agent7.sh)\"", apiKey)
+	output := vm.MustExecute(cmd)
+	t.Log(output)
+	defer s.purge()
+
+	s.assertInstallScript(true)
+	s.assertValidTraceGenerated()
+}
+
 func (s *installUpdaterTestSuite) purge() {
 	t := s.T()
 	vm := s.Env().RemoteHost
 	t.Helper()
+	vm.Execute("sudo datadog-installer purge")
 	if _, err := vm.Execute("command -v apt"); err == nil {
 		t.Log("Uninstall with apt")
 		// remove all datadog packages


### PR DESCRIPTION
Downloads & uses the [installer install script](https://install.datad0g.com/scripts/install.sh) when using remote updates.

The installer install script must be pinned to the agent version and thus lives in the agent repository