### PR TITLE
[AGENTRUN-224] Modify DD_FIPS_MODE to install the datadog-fips-agent instead of fips-proxy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Release Notes
 Unreleased
 ================
 
+- Change DD_FIPS_MODE behavior to install the `datadog-fips-agent` instead of the `datadog-fips-proxy`
+
 1.37.0
 ================
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The install script allows installation of different flavors of the Agent binarie
 
 | Variable | Description|
 |-|-|
-|`DD_AGENT_FLAVOR`|The Agent binary to install. Possible values are `datadog-agent`(default), `datadog-iot-agent`, `datadog-dogstatsd`, `datadog-fips-proxy`, `datadog-heroku-agent`.|
+|`DD_AGENT_FLAVOR`|The Agent binary to install. Possible values are `datadog-agent`(default), `datadog-iot-agent`, `datadog-dogstatsd`, `datadog-fips-agent`, `datadog-heroku-agent`.|
 |`DD_API_KEY`|The application key to access Datadog's programatic API.|
 |`DD_SITE`|The site of the Datadog intake to send Agent data to. For example, `datadoghq.com`. For more information on Datadog sites, see [Getting Started with Datadog Sites](https://docs.datadoghq.com/getting_started/site/).|
 |`DD_URL`|The host of the Datadog intake server to send metrics to. For example, `https://app.datadoghq.com`. Only set this option if you need the Agent to send metrics to a custom URL: it overrides the site setting defined in `site`. It does not affect APM, Logs or Live Process intake which have their own `*_dd_url` settings.|
@@ -28,7 +28,7 @@ The install script allows installation of different flavors of the Agent binarie
 |`DD_TAGS`|List of host tags, defined as a comma-separated list of `key:value` strings. For example, `team:infra,env:prod`. Host tags are attached in-app to every metric, event, log, trace, and service check emitted by this Agent.|
 |`DD_HOST_TAGS`|Deprecated, use `DD_TAGS` instead.|
 |`DD_UPGRADE`|Set to any value to trigger a version upgrade from datadog-agent 5. Imports configuration files from `/etc/dd-agent/datadog.conf`. Not compatible with `DD_AGENT_FLAVOR=datadog-dogstatsd`.|
-|`DD_FIPS_MODE`|Set to any value to enable the use of the FIPS proxy to send data to the DataDog backend. Enabling this option forces all outgoing traffic from the Agent to the local proxy. It's important to note that enabling this will not make the Datadog Agent FIPS compliant, but will force all outgoing traffic to a local FIPS compliant proxy. By-pass `DD_SITE` and `DD_URL` when enabled. For more information on FIPS compliance, see [FIPS Compliance](https://docs.datadoghq.com/agent/configuration/agent-fips-proxy/).|
+|`DD_FIPS_MODE`|Set to any value to install the `datadog-fips-agent` binary which installs the OpenSSL FIPS provider and utilizes OpenSSL bindings for FIPS compliant cryptography primatives and encryption algorithms, see [Datadog FIPS Agent](https://docs.datadoghq.com/agent/guide/fips-agent/?tab=linux#installation).|
 |`DD_ENV`|The environment name where the Agent is running. The environment name is attached in-app to every metric, event, log, trace, and service check emitted by this Agent.|
 |`DD_APM_INSTRUMENTATION_ENABLED`|Automatically instrument all your application processes alongside Agent installation. Possible values are `host`, `docker` or `all` (`all` is both `host` and `docker`). The `docker` value checks if Docker is installed and sets `DD_NO_INSTALL` to `true`. If `DD_APM_INSTRUMENTATION_LIBRARIES` is not set, it enables all libraries: `java`, `js`, `python`, `dotnet` and `ruby`. `host` injection is not compatible with the `DD_NO_AGENT_INSTALL` option. Only supported on Agent v7. Not supported on SUSE.|
 |`DD_APM_INSTRUMENTATION_LIBRARIES`|Specify the APM library to be installed. Possible values are `all`, `java`, `js`, `python`, `dotnet` and `ruby`. Does not run the APM injection script, which is triggered by `DD_APM_INSTRUMENTATION_ENABLED`.|

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -283,9 +283,6 @@ function getMapData() {
              "datadog-dogstatsd")
                 DATA="Datadog Dogstatsd"
                 ;;
-             "datadog-fips-proxy")
-                DATA="Datadog FIPS Proxy"
-                ;;
              "datadog-fips-agent")
                 DATA="Datadog FIPS Agent"
                 ;;
@@ -646,11 +643,6 @@ if [ -n "$DD_UPGRADE" ]; then
   upgrade=$DD_UPGRADE
 fi
 
-fips_mode=
-if [ -n "$DD_FIPS_MODE" ]; then
-  fips_mode=$DD_FIPS_MODE
-fi
-
 error_tracking_standalone=
 if [ -n "$DD_APM_ERROR_TRACKING_STANDALONE" ]; then
   error_tracking_standalone=$DD_APM_ERROR_TRACKING_STANDALONE
@@ -669,6 +661,21 @@ fi
 agent_flavor="datadog-agent"
 if [ -n "$DD_AGENT_FLAVOR" ]; then
     agent_flavor=$DD_AGENT_FLAVOR #Eg: datadog-iot-agent
+fi
+
+fips_mode=
+if [ -n "$DD_FIPS_MODE" ]; then
+  fips_mode=$DD_FIPS_MODE
+  if [ -n "$DD_AGENT_FLAVOR" ] && [ "$DD_AGENT_FLAVOR" != "datadog-fips-agent" ] 
+    # return error message
+    ERROR_MESSAGE="DD_FIPS_MODE sets the DD_AGENT_FLAVOR to the datadog-fips-agent but it is currently set to: $DD_AGENT_FLAVOR"
+    ERROR_CODE=$INVALID_PARAMETERS_CODE
+    echo "$ERROR_MESSAGE"
+    report_telemetry
+    exit 1;
+  else
+    agent_flavor="datadog-fips-agent"
+  fi
 fi
 
 datadog_installer=
@@ -788,10 +795,6 @@ else
   services=("$system_service")
 fi
 
-if [ -n "$fips_mode" ]; then
-  services+=("datadog-fips-proxy")
-fi
-
 if [ -n "$remote_updates" ]; then
   services+=("datadog-installer")
 fi
@@ -817,13 +820,10 @@ if [ -z "$etcdir" ]; then
     etcdir="/etc/datadog-agent"
 fi
 
-etcdirfips=/etc/datadog-fips-proxy
-
 if [ -z "$config_file" ]; then
     config_file="$etcdir/datadog.yaml"
 fi
 
-config_file_fips=$etcdirfips/datadog-fips-proxy.cfg
 system_probe_config_file=$etcdir/system-probe.yaml
 security_agent_config_file=$etcdir/security-agent.yaml
 environment_file=/etc/environment
@@ -966,16 +966,8 @@ if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
 fi
 
 if [ -n "$fips_mode" ]; then
-    UNAME_M=$(uname -m)
-    if [[ ${UNAME_M} != "x86_64" ]] && [[ ${UNAME_M} != "aarch64" ]]; then
-        ERROR_MESSAGE="FIPS mode isn't available for your architecture"
-        ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
-        printf "\033[31m$ERROR_MESSAGE\033[0m\n"
-        report_telemetry
-        exit 1;
-    fi
-    if [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch}" -lt 41 ]]; then
-        ERROR_MESSAGE="FIPS mode is only available since version AGENT_MAJOR_VERSION_PLACEHOLDER.41.0 and requested minor version is $agent_minor_version"
+    if [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch}" -lt 64 ]]; then
+        ERROR_MESSAGE="The datadog-fips-agent is only available since version 7.64.x and requested minor version is $agent_minor_version"
         ERROR_CODE=$INVALID_PARAMETERS_CODE
         printf "\033[31m$ERROR_MESSAGE\033[0m\n"
         report_telemetry
@@ -1080,10 +1072,6 @@ if [ "$OS" == "Red Hat" ]; then
       packages=()
     else
       packages=("$agent_flavor")
-    fi
-
-    if [ -n "$fips_mode" ]; then
-      packages+=("datadog-fips-proxy")
     fi
 
     # Install the installer
@@ -1223,10 +1211,6 @@ If the cause is unclear, please contact Datadog support.
       packages=("datadog-signing-keys")
     else
       packages=("$agent_flavor" "datadog-signing-keys")
-    fi
-
-    if [ -n "$fips_mode" ]; then
-     packages+=("datadog-fips-proxy")
     fi
 
     # Install the installer
@@ -1374,9 +1358,6 @@ elif [ "$OS" == "SUSE" ]; then
     packages=()
   else
     packages=("$agent_flavor")
-  fi
-  if [ -n "$fips_mode" ]; then
-    packages+=("datadog-fips-proxy")
   fi
 
     # Install the installer
@@ -1741,12 +1722,6 @@ if [ ! "$no_agent" ]; then
   $sudo_cmd chmod 640 "$config_file"
 fi
 
-# set the FIPS configuration
-if [ -n "$fips_mode" ]; then
-  ensure_config_file_exists "$sudo_cmd" "$config_file_fips" "dd-agent"
-  # TODO: set port range in file, or environment variable
-fi
-
 # set the system-probe configuration
 if [ -n "$system_probe_ensure_config" ]; then
   ensure_config_file_exists "$sudo_cmd" "$system_probe_config_file" "root"
@@ -1803,11 +1778,6 @@ if [ ! "$no_agent" ] && ! is_installed_by_installer "$sudo_cmd" "datadog-agent";
   $sudo_cmd sh -c "exec cat > $etcdir/install_info " <<EOF
 $install_info_content
 EOF
-fi
-
-if [ -n "$fips_mode" ]; then
-  # Creating or overriding the install information
-  $sudo_cmd sh -c "echo '$install_info_content' > $etcdirfips/install_info"
 fi
 
 # On SUSE 11, sudo service datadog-agent start fails (because /sbin is not in a base user's path)

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -587,6 +587,49 @@ function install_installer() {
     return "$exit_status"
 }
 
+function remove_existing_packages_for_fips_flavor() {
+  local sudo_cmd="$1"
+  local os="$2"
+  local distribution="$3"
+  local packages_to_uninstall="$4"
+
+  local exit_status=0
+  # find if fips-proxy or existing agent is installed
+  if [ "$os" == "Debian" ]; then
+      $sudo_cmd apt list --installed "datadog-agent" "datadog-fips-proxy" 2>/dev/null | grep -q "datadog" || exit_status=$?
+  elif [ "$os" == "Red Hat" ]; then
+      $sudo_cmd yum list installed "datadog-agent" "datadog-fips-proxy" || exit_status=$?
+  elif [ "$os" == "SUSE" ]; then
+      $sudo_cmd zypper search -i "datadog-agent" "datadog-fips-proxy" || exit_status=$?
+  else
+      return 0
+  fi
+
+  if [ "$exit_status" -eq 0 ]; then
+      read -p "Found existing datadog-agent or datadog-fips-proxy installation. These packages will be removed for the datadog-fips-agent to be installed. Do you wish to continue? [y/N]: " -n 1 -r
+      if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+          ERROR_MESSAGE="Unable to install datadog-fips-agent when existing datadog-agent or datadog-fips-proxy installed. Exiting."
+          ERROR_CODE=$INVALID_PARAMETERS_CODE
+          echo "$ERROR_MESSAGE"
+          report_telemetry
+          exit 1;
+      fi
+  else
+      return 0
+  fi
+
+  echo -e "\033[34m\n* Removing the datadog-fips-proxy and existing datadog-agent packages\n\033[0m"
+  if [ "$os" == "Debian" ]; then
+      $sudo_cmd apt-get remove -y --force-yes "datadog-fips-proxy" "datadog-agent" || return $?
+  elif [ "$os" == "Red Hat" ]; then
+      $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' remove "datadog-fips-proxy" "datadog-agent" || $sudo_cmd yum -y remove "datadog-fips-proxy" "datadog-agent" || return $?
+  elif [ "$os" == "SUSE" ]; then
+      $sudo_cmd zypper --non-interactive --no-refresh remove "datadog-fips-proxy" "datadog-agent" || return $?
+  else
+      return 0
+  fi
+}
+
 echo -e "\033[34m\n* Datadog INSTALL_SCRIPT_REPORT_VERSION_PLACEHOLDER install script v${install_script_version}\n\033[0m"
 
 ##
@@ -665,17 +708,17 @@ fi
 
 fips_mode=
 if [ -n "$DD_FIPS_MODE" ]; then
-  fips_mode=$DD_FIPS_MODE
-  if [ -n "$DD_AGENT_FLAVOR" ] && [ "$DD_AGENT_FLAVOR" != "datadog-fips-agent" ] 
-    # return error message
-    ERROR_MESSAGE="DD_FIPS_MODE sets the DD_AGENT_FLAVOR to the datadog-fips-agent but it is currently set to: $DD_AGENT_FLAVOR"
-    ERROR_CODE=$INVALID_PARAMETERS_CODE
-    echo "$ERROR_MESSAGE"
-    report_telemetry
-    exit 1;
-  else
-    agent_flavor="datadog-fips-agent"
-  fi
+    fips_mode=$DD_FIPS_MODE
+    if [ -n "$DD_AGENT_FLAVOR" ] && [ "$DD_AGENT_FLAVOR" != "datadog-fips-agent" ]; then
+        # return error message
+        ERROR_MESSAGE="DD_FIPS_MODE sets the DD_AGENT_FLAVOR to the datadog-fips-agent but it is currently set to: $DD_AGENT_FLAVOR"
+        ERROR_CODE=$INVALID_PARAMETERS_CODE
+        echo "$ERROR_MESSAGE"
+        report_telemetry
+        exit 1;
+    else
+        agent_flavor="datadog-fips-agent"
+    fi
 fi
 
 datadog_installer=
@@ -966,6 +1009,15 @@ if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
 fi
 
 if [ -n "$fips_mode" ]; then
+    UNAME_M=$(uname -m)
+    if [[ ${UNAME_M} != "x86_64" ]] && [[ ${UNAME_M} != "aarch64" ]]; then
+        ERROR_MESSAGE="FIPS mode isn't available for your architecture"
+        ERROR_CODE=$UNSUPPORTED_PLATFORM_CODE
+        printf "\033[31m$ERROR_MESSAGE\033[0m\n"
+        report_telemetry
+        report_telemetry
+        exit 1;
+    fi
     if [[ -n "$agent_minor_version_without_patch" ]] && [[ "${agent_minor_version_without_patch}" -lt 64 ]]; then
         ERROR_MESSAGE="The datadog-fips-agent is only available since version 7.64.x and requested minor version is $agent_minor_version"
         ERROR_CODE=$INVALID_PARAMETERS_CODE
@@ -1077,6 +1129,7 @@ if [ "$OS" == "Red Hat" ]; then
     # Install the installer
     # Note: this function will remove installed packages from the "packages" array
     install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_REMOTE_UPDATES" "$DD_APM_INSTRUMENTATION_ENABLED" "packages" || true
+    remove_existing_packages_for_fips_flavor "$sudo_cmd" "$OS" "$DISTRIBUTION"
 
     # packages can be empty if no_agent is set
     if [ ${#packages[@]} -ne 0 ]; then
@@ -1216,6 +1269,7 @@ If the cause is unclear, please contact Datadog support.
     # Install the installer
     # Note: this function will remove installed packages from the "packages" array
     install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_REMOTE_UPDATES" "$DD_APM_INSTRUMENTATION_ENABLED" "packages" || true
+    remove_existing_packages_for_fips_flavor "$sudo_cmd" "$OS" "$DISTRIBUTION"
 
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
 
@@ -1363,6 +1417,7 @@ elif [ "$OS" == "SUSE" ]; then
     # Install the installer
     # Note: this function will remove installed packages from the "packages" array
     install_installer "$sudo_cmd" "$OS" "$DISTRIBUTION" "$DD_INSTALLER" "$DD_REMOTE_UPDATES" "$DD_APM_INSTRUMENTATION_ENABLED" "packages" || true
+    remove_existing_packages_for_fips_flavor "$sudo_cmd" "$OS" "$DISTRIBUTION"
 
   if [ ${#packages[@]} -ne 0 ]; then
     echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"


### PR DESCRIPTION
Here is a recording of the script removing the existing fips-proxy and agent install then installing the datadog-fips-agent successfully: https://drive.google.com/file/d/13hVPU5Gfmsa2g4vIAc0k-5pzi1o0uYy1/view?usp=sharing

* Remove fips-proxy from install script
* Remove existing non-fips datadog-agent and datadog-fips-proxy packages if present when trying to install the datadog-fips-agent