### PR TITLE
(fleet) drop support for older agents with remote agent management

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -635,7 +635,13 @@ function install_managed_agent() {
   installer_domain=${DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE:-$([[ "$DD_SITE" == "datad0g.com" ]] && echo "install.datad0g.com" || echo "install.datadoghq.com")}
   installer_url="https://${installer_domain}/scripts/install.sh"
   if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
-    installer_url="https://${installer_domain}/scripts/install-7.${DD_AGENT_MINOR_VERSION}.sh"
+    minor_version=${DD_AGENT_MINOR_VERSION}
+    minor_version_without_patch=${minor_version%%[.~]*}
+    if [ "$minor_version_without_patch" -lt 65 ]; then
+      echo "Warning: Remote Agent Management is not supported for agent versions less than 7.65. Switching to 7.65."
+      minor_version="65.1"
+    fi
+    installer_url="https://${installer_domain}/scripts/install-7.${minor_version}.sh"
   fi
   if command -v curl >/dev/null; then
     http_code=$(curl -ILsf --retry 3 -w "%{http_code}" -o /dev/null "$installer_url" || true)


### PR DESCRIPTION
This PR enforces 7.65+ when installing with remote agent management enabled. We previously gave preview commands from the UI that pinned older version that we don't want to support moving forward. Re-running the script will upgrade to 7.65.1.