### PR TITLE
(fleet) trigger installer trace from exit trap

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -43,6 +43,12 @@ UNSUPPORTED_PLATFORM_CODE=5
 INVALID_PARAMETERS_CODE=6
 UNABLE_TO_INSTALL_DEPENDENCY_CODE=7
 
+# Trace creation
+trace_id=$(od -An -N8 -tu8 < /dev/urandom | tr -d ' ')
+start_time=$(date +%s%N)
+export DATADOG_TRACE_ID=$trace_id
+export DATADOG_PARENT_ID=$trace_id
+
 # Set up a named pipe for logging
 npipe=/tmp/$$.tmp
 mknod $npipe p
@@ -51,7 +57,6 @@ mknod $npipe p
 tee <$npipe $logfile &
 exec 1>&-
 exec 1>$npipe 2>&1
-trap 'rm -f $npipe' EXIT
 
 ##
 # REPORTING AND COMMON METHODS
@@ -338,17 +343,10 @@ function json_escape() {
 
 function report_installer_telemetry() {
     local trace_id="$1"
-    local os="$2"
-    local distribution="$3"
-    local start_time="$4"
-    local exit_code="$5"
-    local install_stdout="$6"
-    local install_stderr="$7"
-    local packages_to_install="$8"
-    local packages_to_install_after_installer="$9"
+    local start_time="$2"
+    local exit_code="$3"
 
-    install_stdout=$(json_escape "$install_stdout")
-    install_stderr=$(json_escape "$install_stderr")
+    logs=$(json_escape "$(cat $logfile)")
 
     local time_now_seconds
     local time_now
@@ -378,8 +376,8 @@ function report_installer_telemetry() {
         "origin": "linux-install-script",
         "host": {
             "hostname": "$(json_escape "$(uname -n)")",
-            "os": "$(json_escape "${os}")",
-            "distribution": "$(json_escape "${distribution}")",
+            "os": "$(json_escape "$(uname -o)")",
+            "distribution": "$(json_escape "$(lsb_release -ds)")",
             "architecture": "$(json_escape "$(uname -m)")",
             "kernel_version": "$(json_escape "$(uname -v)")",
             "kernel_name": "$(json_escape "$(uname -s)")",
@@ -431,7 +429,7 @@ function report_installer_telemetry() {
 END
 )
 
-    json_logs="[{\"message\": \"$install_stdout\", \"level\": \"DEBUG\", \"trace_id\": \"${trace_id}\", \"span_id\": \"${trace_id}\"}, {\"message\": \"$install_stderr\", \"level\": \"ERROR\", \"trace_id\": \"${trace_id}\", \"span_id\": \"${trace_id}\"}]"
+    json_logs="[{\"message\": \"$logs\", \"level\": \"DEBUG\", \"trace_id\": \"${trace_id}\", \"span_id\": \"${trace_id}\"}]"
 
     telemetry_logs=$(cat <<-END
     {
@@ -443,8 +441,8 @@ END
         "origin": "linux-install-script",
         "host": {
             "hostname": "$(json_escape "$(uname -n)")",
-            "os": "$(json_escape "${os}")",
-            "distribution": "$(json_escape "${distribution}")",
+            "os": "$(json_escape "$(uname -o)")",
+            "distribution": "$(json_escape "$(lsb_release -ds)")",
             "architecture": "$(json_escape "$(uname -m)")",
             "kernel_version": "$(json_escape "$(uname -v)")",
             "kernel_name": "$(json_escape "$(uname -s)")",
@@ -483,6 +481,12 @@ END
     fi
     echo "$telemetry_trace" | $sudo_cmd tee /tmp/datadog-installer-trace.json > /dev/null
 }
+
+function on_exit() {
+    rm -f $npipe
+    report_installer_telemetry "$trace_id" "$start_time" "$?"
+}
+trap on_exit EXIT
 
 function _install_installer() {
     local sudo_cmd="$1"
@@ -581,7 +585,6 @@ function install_installer() {
 
     install_stdout=$(cat /tmp/datadog-installer-stdout.log)
     install_stderr=$(cat /tmp/datadog-installer-stderr.log)
-    (report_installer_telemetry "$trace_id" "$os" "$distribution" "$start_time" "$exit_status" "$install_stdout" "$install_stderr" "${packages_to_install[*]}" "${packages_to_install_after_installer[*]}") || true
     if [ "$exit_status" -ne 0 ] && { [ -n "$datadog_installer" ] || [ -n "$remote_updates" ]; } then
         echo -e "\033[31m\n* Failed to install the Datadog installer\n\033[0m"
         echo "$install_stderr"


### PR DESCRIPTION
This PR triggers the installer trace from an EXIT trap, ensuring it's always called.