### PR TITLE
Remove local `install_script_version` from `report_installer_telemetry`

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -74,7 +74,7 @@ fi
 function on_exit() {
     exit_code=$?
     rm -f $npipe
-    report_installer_telemetry "$sudo_cmd" "$DD_API_KEY" "$DD_SITE" "$telemetry_url" "$trace_id" "$logfile" "$start_time" "$exit_code" "$install_script_version" || true
+    report_installer_telemetry "$sudo_cmd" "$DD_API_KEY" "$DD_SITE" "$telemetry_url" "$trace_id" "$logfile" "$start_time" "$exit_code" || true
 }
 trap on_exit EXIT
 
@@ -373,7 +373,6 @@ function report_installer_telemetry() {
     local logfile="$6"
     local start_time="$7"
     local exit_code="$8"
-    local install_script_version="$9"
 
     logs=$(json_escape "$(cat "$logfile")")
 


### PR DESCRIPTION
### What does this PR do
* Removes local version of `install_script_version` from the telemetry installer function

### Motivation
* The variable was added as a best practice in bash for safety (modifications to it are scoped to this function, stays stable within said function).
* However, there's no modification for said variable, no possible shadowing as the global `install_script_version` is never modified or re-instantiated by a different function, so we can ignore the argument above.
* Moreover, it breaks our `pre_release` task: https://github.com/DataDog/agent-linux-install-script/blob/3ec421b451b07b666fa092965033d784f23a6cae/Makefile#L71

### Alternative
* We could also modify our `sed` to instead avoid replacing `="$9"`