### PR TITLE
[incident-41054] Removed security archive

### DIFF
--- a/test/sources11.list
+++ b/test/sources11.list
@@ -4,5 +4,3 @@ deb http://archive.debian.org/debian bullseye-updates main
 deb-src http://archive.debian.org/debian bullseye-updates main
 deb http://archive.debian.org/debian bullseye-backports main
 deb-src http://archive.debian.org/debian bullseye-backports main
-deb http://archive.debian.org/debian-security bullseye/updates main
-deb-src http://archive.debian.org/debian-security bullseye/updates main


### PR DESCRIPTION
Only some repos have been moved, we have this error: `E: The repository 'http://archive.debian.org/debian-security bullseye/updates Release' does not have a Release file.`.

This fixes the error.