### PR TITLE
fix(tests): Use TEST_PIPELINE_ID in E2E tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -314,6 +314,10 @@ e2e:
     - generate-scripts
     - go_e2e_deps
   before_script:
+    # Default before_script
+    - '[ -z "$MAJOR_VERSION" ] && export MAJOR_VERSION=${DEFAULT_MAJOR_VERSION}'
+    - '[ ! -z "$TEST_PIPELINE_ID" ] && export TESTING_YUM_VERSION_PATH="testing/pipeline-${TEST_PIPELINE_ID}-a${MAJOR_VERSION}/${MAJOR_VERSION}"'
+    - '[ ! -z "$TEST_PIPELINE_ID" ] && export TESTING_APT_REPO_VERSION="stable-x86_64 ${MAJOR_VERSION}"'
     # Setup AWS Credentials
     - mkdir -p ~/.aws
     - aws ssm get-parameter --region us-east-1 --name ci.agent-linux-install-script.agent-qa-profile --with-decryption --query "Parameter.Value" --out text >> ~/.aws/config

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -106,7 +106,23 @@ func (s *linuxInstallerTestSuite) InstallAgent(agentVersion int, extraParam ...s
 			installationScriptPath = "scripts/install_script_agent6.sh"
 		}
 	}
+
 	extraParamLength := len(extraParam)
+	if agentVersion == 7 && extraParamLength == 0 {
+		if val, ok := os.LookupEnv("TESTING_YUM_VERSION_PATH"); ok {
+			scriptEnvVariable = scriptEnvVariable + fmt.Sprintf(" TESTING_YUM_VERSION_PATH='%s'", val)
+		}
+		if val, ok := os.LookupEnv("TESTING_APT_REPO_VERSION"); ok {
+			scriptEnvVariable = scriptEnvVariable + fmt.Sprintf(" TESTING_APT_REPO_VERSION='%s'", val)
+		}
+		if val, ok := os.LookupEnv("TESTING_YUM_URL"); ok {
+			scriptEnvVariable = scriptEnvVariable + fmt.Sprintf(" TESTING_YUM_URL='%s'", val)
+		}
+		if val, ok := os.LookupEnv("TESTING_APT_URL"); ok {
+			scriptEnvVariable = scriptEnvVariable + fmt.Sprintf(" TESTING_APT_URL='%s'", val)
+		}
+	}
+
 	if extraParamLength == 0 {
 		t.Logf("Install latest Agent %d", agentVersion)
 	} else {


### PR DESCRIPTION
While other tests use the agent build if the install script pipeline is triggered by the agent pipeline; the E2E don't. This PR fixes it.

Example pipeline: https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/pipelines/71845068