### PR TITLE
[SINT-3627] Support TESTING_KEYS_URL in E2E tests

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -121,6 +121,9 @@ func (s *linuxInstallerTestSuite) InstallAgent(agentVersion int, extraParam ...s
 		if val, ok := os.LookupEnv("TESTING_APT_URL"); ok {
 			scriptEnvVariable = scriptEnvVariable + fmt.Sprintf(" TESTING_APT_URL='%s'", val)
 		}
+		if val, ok := os.LookupEnv("TESTING_KEYS_URL"); ok {
+			scriptEnvVariable = scriptEnvVariable + fmt.Sprintf(" TESTING_KEYS_URL='%s'", val)
+		}
 	}
 
 	if extraParamLength == 0 {


### PR DESCRIPTION
#353 changed E2E tests to use testing packages from the upstream pipeline (if there is one).

In `datadog-agent`, we are soon going to use a dedicated testing location for signing keys, which needs to be passed to any test that use testing packages built by the `datadog-agent` pipeline. Therefore, the `TESTING_KEYS_URL` variable needs to be passed to the install script used in the E2E test.