### PR TITLE
update and centralize images for obs-pipelines-worker and vector

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -269,14 +269,14 @@ test-observability-pipelines-worker:
   parallel:
     matrix:
       - IMAGE:
-          [
+          &common_images [
             amazonlinux:2,
             amazonlinux:2023,
-            debian:10,
             debian:11,
+            debian:12,
             rockylinux:9.0,
-            ubuntu:20.04,
             ubuntu:22.04,
+            ubuntu:24.04,
           ]
         DD_OPW_INSTALL_CLASSIC_AGENT: ["", install_script_agent7.sh]
   script:
@@ -293,16 +293,7 @@ test-vector:
     SCRIPT: ./install_script_vector0.sh
   parallel:
     matrix:
-      - IMAGE:
-          [
-            amazonlinux:2,
-            amazonlinux:2023,
-            debian:10,
-            debian:11,
-            rockylinux:9.0,
-            ubuntu:20.04,
-            ubuntu:22.04,
-          ]
+      - IMAGE: *common_images
   script:
     - ./test/vector-test.sh
 
@@ -466,7 +457,6 @@ deploy:
       )
       )
     - aws --region "us-east-1" cloudfront create-invalidation --distribution-id "E2VSER0FO39KRV" --paths "/scripts/*"
-
 
 deploy_deprecated:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:$CI_IMAGE_AGENT_DEPLOY


### PR DESCRIPTION
move to non-eol images for these tests

replaces https://github.com/DataDog/agent-linux-install-script/pull/357