### PR TITLE
Adjust CI for TestInstallDiscovery

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -378,7 +378,7 @@ e2e:
           - --run TestInstallSystemProbeSuite
           - --run TestInstallComplianceAgentSuite
           - --run TestInstallErrorTrackingStandaloneSuite
-          - --skip Test(Install|Upgrade5|Upgrade6|Upgrade7|InstallFips|InstallErrorTrackingStandalone|InstallMaximalAndRetry|InstallSecurityAgent|InstallSystemProbe|InstallComplianceAgent|InstallUpdater)Suite
+          - --skip Test(Install|Upgrade5|Upgrade6|Upgrade7|InstallDiscovery|InstallFips|InstallErrorTrackingStandalone|InstallMaximalAndRetry|InstallSecurityAgent|InstallSystemProbe|InstallComplianceAgent|InstallUpdater)Suite
       - FLAVOR: datadog-agent
         PLATFORM:
           - Debian_11
@@ -401,7 +401,7 @@ e2e:
           - --run TestInstallSecurityAgentSuite
           - --run TestInstallSystemProbeSuite
           - --run TestInstallComplianceAgentSuite
-          - --skip Test(Install|Upgrade5|Upgrade6|Upgrade7|InstallFips|InstallErrorTrackingStandalone|InstallMaximalAndRetry|InstallSecurityAgent|InstallSystemProbe|InstallComplianceAgent|InstallUpdater)Suite
+          - --skip Test(Install|Upgrade5|Upgrade6|Upgrade7|InstallDiscovery|InstallFips|InstallErrorTrackingStandalone|InstallMaximalAndRetry|InstallSecurityAgent|InstallSystemProbe|InstallComplianceAgent|InstallUpdater)Suite
       - FLAVOR: datadog-agent
         PLATFORM:
           - Debian_11


### PR DESCRIPTION
Adjust CI for TestInstallDiscovery to be more like the other tests:

(1) It's currently running twice for non-Centos_6, once in a separate
    job and one as part of the "rest" job which is supposed to skip the
    ones run in separate jobs.  Add it to the skip to fix this.

(2) It's always attempted to be run on CentOS 6 and it get skipped in
    the test itself, but skip it explicitly here just like the other
    tests.