### PR TITLE
Enable logs_config.process_exclude_agent for process logs

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1695,6 +1695,9 @@ function update_logs_config_process_collect_all(){
   $sudo_cmd sh -c "exec cat - '${config_file}.orig' > '$config_file'" <<EOF
 logs_enabled: true
 
+logs_config:
+  process_exclude_agent: true
+
 process_config:
   process_collection:
     use_wlm: true

--- a/test/e2e/install_logs_config_process_collect_all_test.go
+++ b/test/e2e/install_logs_config_process_collect_all_test.go
@@ -77,6 +77,11 @@ func (s *installLogsConfigProcessCollectAllTestSuite) assertInstallScript() {
 	assert.True(t, exists, "extra_config_providers should exist")
 	assert.Contains(t, extraConfigProviders, "process_log")
 
+	// Assert logs_config.process_exclude_agent is true
+	logsConfig, exists := datadogConfig["logs_config"].(map[any]any)
+	assert.True(t, exists, "logs_config should exist")
+	assert.Equal(t, true, logsConfig["process_exclude_agent"])
+
 	// Check system-probe.yaml configuration (should have discovery enabled)
 	systemProbeConfig := unmarshalConfigFile(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
 	assert.Equal(t, true, systemProbeConfig["discovery"].(map[any]any)["enabled"])

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -293,6 +293,10 @@ testLogsConfigProcessCollectAll() {
   # Test extra_config_providers contains process_log
   sudo sed -e '0,/^extra_config_providers:/d' -e '/^[^ ]/,$d' $config_file | grep -v "#" | grep -q "process_log"
   assertEquals 0 $?
+
+  # Test logs_config.process_exclude_agent is set to true
+  sudo sed -e '0,/^logs_config:/d' -e '/^[^ ]/,$d' $config_file | grep -v "#" | grep -q "process_exclude_agent: true"
+  assertEquals 0 $?
 }
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
For process log collection, we want to have the agent logs to be excluded, so set the required option.

https://datadoghq.atlassian.net/browse/DSCVR-180