### PR TITLE
Enable logs_config.auto_multi_line_detection for process logs

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1800,6 +1800,7 @@ logs_enabled: true
 
 logs_config:
   process_exclude_agent: true
+  auto_multi_line_detection: true
 
 process_config:
   process_collection:

--- a/test/e2e/install_logs_config_process_collect_all_test.go
+++ b/test/e2e/install_logs_config_process_collect_all_test.go
@@ -82,6 +82,9 @@ func (s *installLogsConfigProcessCollectAllTestSuite) assertInstallScript() {
 	assert.True(t, exists, "logs_config should exist")
 	assert.Equal(t, true, logsConfig["process_exclude_agent"])
 
+	// Assert logs_config.auto_multi_line_detection is true
+	assert.Equal(t, true, logsConfig["auto_multi_line_detection"])
+
 	// Check system-probe.yaml configuration (should have discovery enabled)
 	systemProbeConfig := unmarshalConfigFile(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
 	assert.Equal(t, true, systemProbeConfig["discovery"].(map[any]any)["enabled"])

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -297,6 +297,10 @@ testLogsConfigProcessCollectAll() {
   # Test logs_config.process_exclude_agent is set to true
   sudo sed -e '0,/^logs_config:/d' -e '/^[^ ]/,$d' $config_file | grep -v "#" | grep -q "process_exclude_agent: true"
   assertEquals 0 $?
+
+  # Test logs_config.auto_multi_line_detection is set to true
+  sudo sed -e '0,/^logs_config:/d' -e '/^[^ ]/,$d' $config_file | grep -v "#" | grep -q "auto_multi_line_detection: true"
+  assertEquals 0 $?
 }
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
Add auto_multi_line_detection: true to the logs_config section when enabling process log collection. This enables automatic detection of multi-line log entries for process logs.

Updated tests to verify the new configuration is properly set.

https://datadoghq.atlassian.net/browse/DSCVR-184