### PR TITLE
[tests] Add script_failure to retry conditions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,7 @@ default:
       - scheduler_failure
       - stale_schedule
       - data_integrity_failure
+      - script_failure
   # Handle inputs when running as a downstream pipeline from the datadog-agent repo
   before_script:
     - '[ -z "$MAJOR_VERSION" ] && export MAJOR_VERSION=${DEFAULT_MAJOR_VERSION}'


### PR DESCRIPTION
Adds `script_failure` as a condition for retrying e2e tests, to resolve flakey tests that were caused by failures in gitlab scripts ([example](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/1120962269#L141))