### PR TITLE
fix(unit_test): Change the matching regexp

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1677,12 +1677,12 @@ function update_security_and_or_compliance(){
   if [ "$enable_security" == "true" ]; then
     printf "\033[34m\n* Enabling runtime security in $local_config_file configuration\n\033[0m\n"
     $sudo_cmd sh -c "sed -i 's/^#\s*runtime_security_config:$/runtime_security_config:/' $local_config_file"
-    $sudo_cmd sh -c "sed -i '/^runtime_security_config:/,// s/\(\s\+\)#\s*enabled:\s*false/\1enabled: true/' $local_config_file"
+    $sudo_cmd sh -c "sed -i '/^runtime_security_config:/,// s/\s*#\(\s\+\)enabled:\s*false/\1 enabled: true/' $local_config_file"
   fi
   if [ "$enable_compliance" == "true" ]; then
     printf "\033[34m\n* Enabling compliance monitoring in $local_config_file configuration\n\033[0m\n"
     $sudo_cmd sh -c "sed -i 's/^#\s*compliance_config:$/compliance_config:/' $local_config_file"
-    $sudo_cmd sh -c "sed -i '/^compliance_config:/,// s/\(\s\+\)#\s*enabled:\s*false/\1enabled: true/' $local_config_file"
+    $sudo_cmd sh -c "sed -i '/^compliance_config:/,// s/\s*#\(\s\+\)enabled:\s*false/\1 enabled: true/' $local_config_file"
   fi
 }
 function update_error_tracking_standalone(){


### PR DESCRIPTION
Since the 12th of september, probably because of
https://github.com/DataDog/datadog-agent/pull/40593/, the update of the status for security or compliance configuration is broken. With this new regex the change should be ok.

- Tested on a vm started with test-infra-definition on a recent pipeline. 
- UT are running on the last stable, so if the CI is green there is no regression compared to the past