### PR TITLE
fix(ssi): allow script pinning for agent E2Es

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -643,7 +643,13 @@ function install_apm_ssi() {
   fi
 
   installer_domain=${DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE:-$([[ "$DD_SITE" == "datad0g.com" ]] && echo "install.datad0g.com" || echo "install.datadoghq.com")}
-  installer_url="https://${installer_domain}/scripts/install-ssi.sh" # TODO: support pinning?
+
+  # Technical option to test with non-production install-ssi.sh scripts
+  if [ -n "$DD_APM_INSTRUMENTATION_PIPELINE_ID" ]; then
+    installer_domain="${installer_domain}/pipeline-${DD_APM_INSTRUMENTATION_PIPELINE_ID}"
+  fi
+
+  installer_url="https://${installer_domain}/scripts/install-ssi.sh" # TODO: support version pinning?
   
   _install_installer_script "$installer_url" || true
   filter_packages_installed_by_installer "$sudo_cmd" "$pkg_array_name"


### PR DESCRIPTION
Today it's not possible to pin the APM SSI script; which means that we're enabling race conditions within the agent pipelines between publishing & E2E. This PR allows pinning to a specific pipeline ID.