### PR TITLE
Prepare 1.41.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,10 @@
 Release Notes
 =============
 
-Unreleased
+1.41.1
 ================
+
+- (fleet) Fix system-probe/security-agent configuration files not being created when APM SSI is enabled (#380)
 
 1.41.0
 ================

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -9,7 +9,7 @@ set -e
 
 DEPRECATION_MESSAGE_PLACEHOLDER
 
-install_script_version=1.41.0.post
+install_script_version=1.41.1
 logfile="ddagent-install.log"
 support_email=support@datadoghq.com
 variant=install_scriptINSTALL_INFO_VERSION_PLACEHOLDER

--- a/install_script_op_worker1.sh
+++ b/install_script_op_worker1.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-install_script_version=1.41.0.post
+install_script_version=1.41.1
 logfile="dd-install.log"
 support_email=support@datadoghq.com
 variant=install_script_op_worker1

--- a/install_script_op_worker2.sh
+++ b/install_script_op_worker2.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-install_script_version=1.41.0.post
+install_script_version=1.41.1
 logfile="dd-install.log"
 support_email=support@datadoghq.com
 variant=install_script_op_worker2


### PR DESCRIPTION
Patch release for https://github.com/DataDog/agent-linux-install-script/pull/380, ensuring we create system-probe/security-agent config files when APM SSI is enabled