### PR TITLE
fix(ssi): allow installer only install

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -607,7 +607,7 @@ function _install_installer_script() {
 function install_apm_ssi() {
   local sudo_cmd="$1"
 
-  if [ -z "$DD_APM_INSTRUMENTATION_ENABLED" ]; then
+  if [ -z "$DD_APM_INSTRUMENTATION_ENABLED" ] && [ -z "$DD_INSTALLER" ]; then
     return 0
   fi
 

--- a/test/e2e/install_installer_test.go
+++ b/test/e2e/install_installer_test.go
@@ -77,6 +77,18 @@ func (s *installUpdaterTestSuite) TestInstallWithRemoteUpdates() {
 	s.assertValidTraceGenerated()
 }
 
+func (s *installUpdaterTestSuite) TestInstallerOnlyInstall() {
+	t := s.T()
+	vm := s.Env().RemoteHost
+
+	cmd := "DD_INSTALLER=true DD_NO_AGENT_INSTALL=true bash -c \"$(cat scripts/install_script_agent7.sh)\""
+	output := vm.MustExecute(cmd)
+	t.Log(output)
+	defer s.purge()
+
+	s.assertInstallerInstalled()
+}
+
 func (s *installUpdaterTestSuite) assertInstallScriptWithRemoteUpdates(active bool) {
 	t := s.T()
 	vm := s.Env().RemoteHost
@@ -187,4 +199,12 @@ func (s *installUpdaterTestSuite) assertValidTraceGenerated() {
 	if !json.Valid(rawTrace) {
 		t.Fatalf("Trace is not valid JSON: %s", string(rawTrace))
 	}
+}
+
+func (s *installUpdaterTestSuite) assertInstallerInstalled() {
+	t := s.T()
+	vm := s.Env().RemoteHost
+
+	_, err := vm.Execute("datadog-installer")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
# Overview
In https://github.com/DataDog/agent-linux-install-script/pull/337, this line was removed:
```bash
if [ -z "$apm_instrumentation_enabled" ] && [ -z "$datadog_installer" ] && [ -z "$remote_updates" ]; then
```

It was replaced with only checking if `DD_APM_INSTRUMENTATION_ENABLED` is set. Our integration tests rely on being able to utilize `DD_INSTALL` to be able to install packages on demand for our tests. This has been our short term workaround: https://github.com/DataDog/auto_inject/pull/774

This change ensures we can use the installer in a standalone mechanism.

# Changes
- [fix(ssi): allow installer only install](https://github.com/DataDog/agent-linux-install-script/commit/407447aaa4ad9a057a1d606d32b8aa85fe6b9b0d)
    - This commit fixes an issue where the installer can no longer be installed in isolation.

# Tests
I've added an e2e test that asserts the `datadog-installer` exists in the path.