### PR TITLE
Change sed command for replacement

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1658,12 +1658,12 @@ function update_security_and_or_compliance(){
   if [ "$enable_security" == "true" ]; then
     printf "\033[34m\n* Enabling runtime security in $local_config_file configuration\n\033[0m\n"
     $sudo_cmd sh -c "sed -i 's/^#\s*runtime_security_config:$/runtime_security_config:/' $local_config_file"
-    $sudo_cmd sh -c "sed -i '/^runtime_security_config:/,// s/^\s*# \(\s\+\)enabled:\s*false/\1enabled: true/' $local_config_file"
+    $sudo_cmd sh -c "sed -i '/^runtime_security_config:/,// s/^\s*#\s*enabled:\s*false/  enabled: true/' $local_config_file"
   fi
   if [ "$enable_compliance" == "true" ]; then
     printf "\033[34m\n* Enabling compliance monitoring in $local_config_file configuration\n\033[0m\n"
     $sudo_cmd sh -c "sed -i 's/^#\s*compliance_config:$/compliance_config:/' $local_config_file"
-    $sudo_cmd sh -c "sed -i '/^compliance_config:/,// s/^\s*# \(\s\+\)enabled:\s*false/\1enabled: true/' $local_config_file"
+    $sudo_cmd sh -c "sed -i '/^compliance_config:/,// s/^\s*#\s*enabled:\s*false/  enabled: true/' $local_config_file"
   fi
 }
 function update_error_tracking_standalone(){


### PR DESCRIPTION
https://github.com/DataDog/agent-linux-install-script/pull/376 follow-up

Motivation: fix unit test for 7.72/main, but still keep behaviour valid for previous versions

Tested on 7.71/latest: this is what the CI does, it uses main
Tested on upcoming release locally

Explanation/Root cause
https://github.com/DataDog/datadog-agent/pull/40593
`system-probe.yaml.example` **AFTER** `7.72`:
```yaml
# runtime_security_config:
#   # @param enabled - boolean - optional - default: false
#   # @env DD_RUNTIME_SECURITY_CONFIG_ENABLED - boolean - optional - default: false
#   # Set to true to enable Cloud Workload Security (CWS).
#
#   enabled: false
```
**BEFORE**
```yaml
# runtime_security_config:
  ## @param enabled - boolean - optional - default: false
  ## @env DD_RUNTIME_SECURITY_CONFIG_ENABLED - boolean - optional - default: false
  ## Set to true to enable Cloud Workload Security (CWS).
  #
  # enabled: false
```