### PR TITLE
Add option to enable privileged logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The install script allows installation of different flavors of the Agent binarie
 |`DD_RUNTIME_SECURITY_CONFIG_ENABLED`|If set to `true`, ensure creation of security Agent and system probe configuration file (if they don't already exist), and enable Cloud Workload Security (CWS).|
 |`DD_COMPLIANCE_CONFIG_ENABLED`|If set to `true`, ensures the creation of a security Agent configuration file if one doesn't already exist, and enables Cloud Security Posture Management (CSPM).|
 |`DD_DISCOVERY_ENABLED`|If set to `true`, and a system probe configuration file does not already exist, creates a system probe configuration file and enables Service Discovery.
+|`DD_PRIVILEGED_LOGS_ENABLED`|If set to `true`, and a system probe configuration file does not already exist, creates a system probe configuration file and enables Privileged Logs.
 |`DD_OTELCOLLECTOR_ENABLED`|If set to `true`, and an OTel Collector configuration file does not already exist, creates an OTel Collector configuration file and installs/enables Datadog Distribution of OpenTelemetry (DDOT).
 |`DD_LOGS_CONFIG_PROCESS_COLLECT_ALL`|Enable process log collection.|
 |`DD_INSTALL_ONLY`|Set to any value to prevent starting the Agent after installation.|

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1698,6 +1698,17 @@ discovery:
   enabled: true
 EOF
 }
+function update_privileged_logs(){
+  local sudo_cmd="$1"
+  local config_file="$2"
+
+  printf "\033[34m\n* Setting $nice_flavor configuration to enable Privileged Logs: $config_file\n\033[0m\n"
+  $sudo_cmd cp "$config_file" "${config_file}.orig"
+  $sudo_cmd sh -c "exec cat - '${config_file}.orig' > '$config_file'" <<EOF
+privileged_logs:
+  enabled: true
+EOF
+}
 function update_logs_config_process_collect_all(){
   local sudo_cmd="$1"
   local config_file="$2"
@@ -1762,11 +1773,15 @@ function manage_system_probe_config(){
   local probe_config_file="$2"
   local enable_security="$3"
   local enable_discovery="$4"
-  if [ "$enable_security" == "true" ] || [ "$enable_discovery" == "true" ]; then
+  local enable_privileged_logs="$5"
+  if [ "$enable_security" == "true" ] || [ "$enable_discovery" == "true" ] || [ "$enable_privileged_logs" == "true" ]; then
     if ensure_config_file_exists "$sudo_cmd" "$probe_config_file" "root"; then
       update_security_and_or_compliance "$sudo_cmd" "$probe_config_file" "$enable_security" "false"
       if [ "$enable_discovery" == "true" ]; then
         update_discovery "$sudo_cmd" "$probe_config_file"
+      fi
+      if [ "$enable_privileged_logs" == "true" ]; then
+        update_privileged_logs "$sudo_cmd" "$probe_config_file"
       fi
     fi
   fi
@@ -1846,7 +1861,7 @@ elif [ ! "$no_agent" ]; then
   fi
 
   manage_security_config "$sudo_cmd" "$security_agent_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_COMPLIANCE_CONFIG_ENABLED"
-  manage_system_probe_config "$sudo_cmd" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_DISCOVERY_ENABLED"
+  manage_system_probe_config "$sudo_cmd" "$system_probe_config_file" "$DD_RUNTIME_SECURITY_CONFIG_ENABLED" "$DD_DISCOVERY_ENABLED" "$DD_PRIVILEGED_LOGS_ENABLED"
 fi
 
 # DDOT configuration update

--- a/test/e2e/install_privileged_logs_test.go
+++ b/test/e2e/install_privileged_logs_test.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
+	"github.com/stretchr/testify/assert"
+)
+
+type installPrivilegedLogsTestSuite struct {
+	linuxInstallerTestSuite
+}
+
+func TestInstallPrivilegedLogsSuite(t *testing.T) {
+	if flavor != agentFlavorDatadogAgent {
+		t.Skip("privileged logs test supports only datadog-agent flavor")
+	}
+	stackName := fmt.Sprintf("install-privileged-logs-%s-%s-%s", flavor, platform, getenv("CI_PIPELINE_ID", "dev"))
+	t.Run(stackName, func(t *testing.T) {
+		t.Logf("We will install with system-probe privileged logs %s with install script on %s", flavor, platform)
+		testSuite := &installPrivilegedLogsTestSuite{}
+		e2e.Run(t,
+			testSuite,
+			e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(awshost.WithEC2InstanceOptions(getEC2Options(t)...))),
+			e2e.WithStackName(stackName),
+		)
+	})
+}
+
+func (s *installPrivilegedLogsTestSuite) TestInstallPrivilegedLogs() {
+	s.InstallAgent(7, "DD_PRIVILEGED_LOGS_ENABLED=true DD_SITE=\"datadoghq.com\"", "Install latest Agent 7 with privileged logs")
+
+	s.assertInstallScript()
+
+	s.addExtraIntegration()
+
+	s.uninstall()
+
+	s.assertUninstall()
+
+	s.purge()
+
+	s.assertPurge()
+}
+
+func (s *installPrivilegedLogsTestSuite) assertInstallScript() {
+	s.linuxInstallerTestSuite.assertInstallScript(true)
+	t := s.T()
+	vm := s.Env().RemoteHost
+	t.Log("Assert system probe config is created and security-agent is not created")
+	assertFileExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
+	assertFileNotExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, securityAgentConfigFileName))
+
+	systemProbeConfig := unmarshalConfigFile(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
+	assert.NotContains(t, systemProbeConfig, "runtime_security_config")
+	assert.NotContains(t, systemProbeConfig, "discovery")
+	assert.Equal(t, true, systemProbeConfig["privileged_logs"].(map[any]any)["enabled"])
+}
+
+func (s *installPrivilegedLogsTestSuite) assertUninstall() {
+	s.linuxInstallerTestSuite.assertUninstall()
+	t := s.T()
+	vm := s.Env().RemoteHost
+	t.Log("Assert system probe is there after uninstall")
+	assertFileExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
+}
+
+func (s *installPrivilegedLogsTestSuite) assertPurge() {
+	if s.shouldSkipPurge() {
+		return
+	}
+	s.linuxInstallerTestSuite.assertPurge()
+	t := s.T()
+	vm := s.Env().RemoteHost
+	t.Log("Assert system probe is removed after purge")
+	assertFileNotExists(t, vm, fmt.Sprintf("/etc/%s/%s", s.baseName, systemProbeConfigFileName))
+}

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -225,33 +225,54 @@ testSecurityConfigFullConfig(){
 ### Manage system probe config files
 testSystemProbeConfigNoCreation() {
   sudo rm $system_probe_config_file 2> /dev/null
-  manage_system_probe_config "sudo" $system_probe_config_file false false
+  manage_system_probe_config "sudo" $system_probe_config_file false false false
   sudo test -e $system_probe_config_file
   assertEquals 1 $?
 }
 testSystemProbeConfigSecOn(){
   sudo rm $system_probe_config_file 2> /dev/null
-  manage_system_probe_config "sudo" $system_probe_config_file true false
+  manage_system_probe_config "sudo" $system_probe_config_file true false false
   yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
   assertEquals 0 $?
   assertEquals "$(sudo yq eval '.runtime_security_config.enabled' $system_probe_config_file)" "true"
   assertEquals "$(sudo yq eval '.discovery.enabled' $system_probe_config_file)" "null"
+  assertEquals "$(sudo yq eval '.privileged_logs.enabled' $system_probe_config_file)" "null"
 }
 testSystemProbeConfigDiscoveryOn(){
   sudo rm $system_probe_config_file 2> /dev/null
-  manage_system_probe_config "sudo" $system_probe_config_file false true
+  manage_system_probe_config "sudo" $system_probe_config_file false true false
   yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
   assertEquals 0 $?
   assertEquals "$(sudo yq eval '.runtime_security_config.enabled' $system_probe_config_file)" "null"
   assertEquals "$(sudo yq eval '.discovery.enabled' $system_probe_config_file)" "true"
+  assertEquals "$(sudo yq eval '.privileged_logs.enabled' $system_probe_config_file)" "null"
+}
+testSystemProbeConfigPrivilegedLogsOn(){
+  sudo rm $system_probe_config_file 2> /dev/null
+  manage_system_probe_config "sudo" $system_probe_config_file false false true
+  yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
+  assertEquals 0 $?
+  assertEquals "$(sudo yq eval '.runtime_security_config.enabled' $system_probe_config_file)" "null"
+  assertEquals "$(sudo yq eval '.discovery.enabled' $system_probe_config_file)" "null"
+  assertEquals "$(sudo yq eval '.privileged_logs.enabled' $system_probe_config_file)" "true"
+}
+testSystemProbeConfigPrivilegedLogsAndDiscovery(){
+  sudo rm $system_probe_config_file 2> /dev/null
+  manage_system_probe_config "sudo" $system_probe_config_file false true true
+  yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
+  assertEquals 0 $?
+  assertEquals "$(sudo yq eval '.runtime_security_config.enabled' $system_probe_config_file)" "null"
+  assertEquals "$(sudo yq eval '.discovery.enabled' $system_probe_config_file)" "true"
+  assertEquals "$(sudo yq eval '.privileged_logs.enabled' $system_probe_config_file)" "true"
 }
 testSystemProbeConfigFullConfig(){
   sudo rm $system_probe_config_file 2> /dev/null
-  manage_system_probe_config "sudo" $system_probe_config_file true true
+  manage_system_probe_config "sudo" $system_probe_config_file true true true
   yamllint -c "$yaml_config" --no-warnings $system_probe_config_file
   assertEquals 0 $?
   assertEquals "$(sudo yq eval '.runtime_security_config.enabled' $system_probe_config_file)" "true"
   assertEquals "$(sudo yq eval '.discovery.enabled' $system_probe_config_file)" "true"
+  assertEquals "$(sudo yq eval '.privileged_logs.enabled' $system_probe_config_file)" "true"
 }
 
 ### Test logs config process collect all function


### PR DESCRIPTION
Add an option to enable privileged logs in the system-probe configuration file. The feature is available [from agent 7.72](https://github.com/DataDog/datadog-agent/pull/38470).

https://datadoghq.atlassian.net/browse/DSCVR-193