### PR TITLE
Fix DDOT install for Agent >= 7.78.0

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1242,8 +1242,9 @@ if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
         exit 1;
     fi
     # Starting from 7.78.0, DDOT is installed by the Agent post-install script
+    skip_ddot_package_install=
     if [ -n "$agent_minor_version_without_patch" ] && [ "${agent_minor_version_without_patch}" -ge 78 ]; then
-        DD_OTELCOLLECTOR_ENABLED=
+        skip_ddot_package_install=true
     fi
 fi
 
@@ -1335,7 +1336,7 @@ if [ "$OS" == "Red Hat" ]; then
     # if some packages were previously pinned (using excludepkgs)
     # this will unpin them as a side effect
     $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://${yum_url}/${yum_version_path}/${ARCHI}/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=${rpm_repo_gpgcheck}\npriority=1\ngpgkey=${gpgkeys}' > /etc/yum.repos.d/datadog.repo"
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
       $sudo_cmd sh -c "echo -e '[datadog-ddot]\nname = Datadog, Inc.\nbaseurl = https://${yum_url}/${ddot_yum_version_path}/${ARCHI}/\nenabled=0\ngpgcheck=1\nrepo_gpgcheck=${rpm_repo_gpgcheck}\npriority=1\ngpgkey=${gpgkeys}' > /etc/yum.repos.d/datadog-ddot.repo"
     fi
 
@@ -1383,15 +1384,15 @@ END
 
     # packages can be empty if no_agent is set
     if [ ${#packages[@]} -ne 0 ]; then
-      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
         echo -e "  \033[33mInstalling package(s): ${packages[*]} ${ddot_package}\n\033[0m"
       else
         echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
       fi
 
       # yum has a default retry of 10 https://github.com/Distrotech/yum/blob/f4e54aeed297158c563828aa3ebb93d0c8ce7e38/docs/yum.conf.5#L364-L366
-      $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} yum -y install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
-      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+      $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} yum -y install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
+      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
         $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} yum -y --disablerepo='*' --enablerepo='datadog-ddot' install $dnf_flag ${ddot_package}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} yum -y install $dnf_flag ${ddot_package}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
       fi
 
@@ -1456,7 +1457,7 @@ elif [ "$OS" == "Debian" ]; then
     $sudo_cmd sh -c "echo 'deb [signed-by=${apt_usr_share_keyring}] https://${apt_url}/ ${apt_repo_version}' > /etc/apt/sources.list.d/datadog.list"
     $sudo_cmd sh -c "chmod a+r /etc/apt/sources.list.d/datadog.list"
 
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
       printf "\033[34m\n* Installing APT package sources for Datadog DDOT\n\033[0m\n"
       $sudo_cmd sh -c "echo 'deb [signed-by=${apt_usr_share_keyring}] https://${apt_url}/ ${ddot_apt_repo_version}' > /etc/apt/sources.list.d/datadog-ddot.list"
       $sudo_cmd sh -c "chmod a+r /etc/apt/sources.list.d/datadog-ddot.list"
@@ -1507,7 +1508,7 @@ If the failing repository is Datadog, please contact Datadog support.
 *****
 "
     $sudo_cmd apt-get update -o Dir::Etc::sourcelist="sources.list.d/datadog.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
       $sudo_cmd apt-get update -o Dir::Etc::sourcelist="sources.list.d/datadog-ddot.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
       $sudo_cmd mv /etc/apt/sources.list.d/datadog-ddot.list /etc/apt/sources.list.d/datadog-ddot.list.disabled
     fi
@@ -1546,7 +1547,7 @@ If the cause is unclear, please contact Datadog support.
         $sudo_cmd rm -rf "/opt/datadog-agent/python-scripts/__pycache__"
     fi
 
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
       echo -e "  \033[33mInstalling package(s): ${packages[*]} ${ddot_package}\n\033[0m"
     else
       echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
@@ -1567,8 +1568,8 @@ END
 )"
     start_stage "install_agent_packages"
 
-    $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' apt-get install -o Acquire::Retries='5' -y --force-yes ${packages[*]} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+    $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' DD_OTELCOLLECTOR_ENABLED='${DD_OTELCOLLECTOR_ENABLED}' apt-get install -o Acquire::Retries='5' -y --force-yes ${packages[*]} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
       $sudo_cmd mv /etc/apt/sources.list.d/datadog-ddot.list.disabled /etc/apt/sources.list.d/datadog-ddot.list
       $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' apt-get install -o Acquire::Retries='5' -y --force-yes ${ddot_package} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
       $sudo_cmd mv /etc/apt/sources.list.d/datadog-ddot.list /etc/apt/sources.list.d/datadog-ddot.list.disabled
@@ -1653,7 +1654,7 @@ elif [ "$OS" == "SUSE" ]; then
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"
   $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://${yum_url}/suse/${yum_version_path}/${ARCHI}\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=${rpm_repo_gpgcheck}\ngpgkey=${gpgkeys}' > /etc/zypp/repos.d/datadog.repo"
-  if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+  if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
     echo -e "\033[34m\n* Installing YUM Repository for DDOT\n\033[0m"
     $sudo_cmd sh -c "echo -e '[datadog-ddot]\nname=datadog-ddot\nenabled=0\nbaseurl=https://${yum_url}/suse/${ddot_yum_version_path}/${ARCHI}\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=${rpm_repo_gpgcheck}\ngpgkey=${gpgkeys}' > /etc/zypp/repos.d/datadog-ddot.repo"
   fi
@@ -1661,7 +1662,7 @@ elif [ "$OS" == "SUSE" ]; then
 
   echo -e "\033[34m\n* Refreshing repositories\n\033[0m"
   $sudo_cmd zypper --non-interactive --no-gpg-checks refresh datadog
-  if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+  if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
     $sudo_cmd zypper --non-interactive --no-gpg-checks refresh datadog-ddot
   fi
 
@@ -1731,19 +1732,19 @@ END
 )"
   start_stage "install_agent_packages"
   if [ ${#packages[@]} -ne 0 ]; then
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
       echo -e "  \033[33mInstalling package(s): ${packages[*]} ${ddot_package}\n\033[0m"
     else
       echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
     fi
     # Not yet retry mechanism in zypper, see https://github.com/openSUSE/zypper/issues/420
     if [ -z "$sudo_cmd" ]; then
-      ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
+      DD_OTELCOLLECTOR_ENABLED="${DD_OTELCOLLECTOR_ENABLED}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
     else
-      $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE="${SYSTEMD_OFFLINE:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
+      $sudo_cmd DD_OTELCOLLECTOR_ENABLED="${DD_OTELCOLLECTOR_ENABLED}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE="${SYSTEMD_OFFLINE:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
     fi
 
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
       if [ -z "$sudo_cmd" ]; then
         ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} zypper --non-interactive --no-refresh install "${ddot_package}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
       else

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1247,7 +1247,11 @@ if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
     if [ -z "$agent_minor_version_without_patch" ] || [ "${agent_minor_version_without_patch}" -ge 78 ]; then
         ddot_use_installer=true
         if [ -n "$agent_minor_version_without_patch" ]; then
-            ddot_oci_tag="${agent_major_version}.${clean_agent_minor_version}-1"
+            if echo "${agent_minor_version}" | grep -q '~'; then
+                ddot_oci_tag="${agent_major_version}.$(echo "${agent_minor_version}" | sed 's/~/-/')"
+            else
+                ddot_oci_tag="${agent_major_version}.${agent_minor_version}-1"
+            fi
         fi
     fi
 fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1392,6 +1392,12 @@ END
 
       # yum has a default retry of 10 https://github.com/Distrotech/yum/blob/f4e54aeed297158c563828aa3ebb93d0c8ce7e38/docs/yum.conf.5#L364-L366
       $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} yum -y install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
+      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$agent_minor_version_without_patch" ]; then
+        installed_minor=$($sudo_cmd rpm -q --queryformat '%{VERSION}' datadog-agent 2>/dev/null | cut -d. -f2)
+        if [ -n "$installed_minor" ] && [ "$installed_minor" -ge 78 ]; then
+          skip_ddot_package_install=true
+        fi
+      fi
       if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
         $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} yum -y --disablerepo='*' --enablerepo='datadog-ddot' install $dnf_flag ${ddot_package}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} yum -y install $dnf_flag ${ddot_package}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
       fi
@@ -1569,6 +1575,12 @@ END
     start_stage "install_agent_packages"
 
     $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' DD_OTELCOLLECTOR_ENABLED='${DD_OTELCOLLECTOR_ENABLED}' apt-get install -o Acquire::Retries='5' -y --force-yes ${packages[*]} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$agent_minor_version_without_patch" ]; then
+      installed_minor=$(dpkg-query -W -f='${Version}' datadog-agent 2>/dev/null | grep -oE '7\.[0-9]+' | head -1 | cut -d. -f2)
+      if [ -n "$installed_minor" ] && [ "$installed_minor" -ge 78 ]; then
+        skip_ddot_package_install=true
+      fi
+    fi
     if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
       $sudo_cmd mv /etc/apt/sources.list.d/datadog-ddot.list.disabled /etc/apt/sources.list.d/datadog-ddot.list
       $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' apt-get install -o Acquire::Retries='5' -y --force-yes ${ddot_package} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
@@ -1744,6 +1756,12 @@ END
       $sudo_cmd DD_OTELCOLLECTOR_ENABLED="${DD_OTELCOLLECTOR_ENABLED}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE="${SYSTEMD_OFFLINE:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
     fi
 
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$agent_minor_version_without_patch" ]; then
+      installed_minor=$($sudo_cmd rpm -q --queryformat '%{VERSION}' datadog-agent 2>/dev/null | cut -d. -f2)
+      if [ -n "$installed_minor" ] && [ "$installed_minor" -ge 78 ]; then
+        skip_ddot_package_install=true
+      fi
+    fi
     if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
       if [ -z "$sudo_cmd" ]; then
         ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} zypper --non-interactive --no-refresh install "${ddot_package}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1233,6 +1233,7 @@ if [[ "$agent_flavor" == "datadog-fips-agent" ]]; then
     fi
 fi
 
+skip_ddot_package_install=
 if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
     if [ "$agent_major_version" != "7" ] || { [ -n "$agent_minor_version_without_patch" ] && [ "${agent_minor_version_without_patch}" -lt 69 ]; } then
         ERROR_MESSAGE="The datadog-agent-ddot is only available since version AGENT_MAJOR_VERSION_PLACEHOLDER.69.3 and requested minor version is $agent_minor_version"
@@ -1242,7 +1243,6 @@ if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
         exit 1;
     fi
     # Starting from 7.78.0, DDOT is installed by the Agent post-install script
-    skip_ddot_package_install=
     if [ -n "$agent_minor_version_without_patch" ] && [ "${agent_minor_version_without_patch}" -ge 78 ]; then
         skip_ddot_package_install=true
     fi

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1391,7 +1391,7 @@ END
       fi
 
       # yum has a default retry of 10 https://github.com/Distrotech/yum/blob/f4e54aeed297158c563828aa3ebb93d0c8ce7e38/docs/yum.conf.5#L364-L366
-      $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} yum -y install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
+      $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} DD_INSTALLER_REGISTRY_URL=${DD_INSTALLER_REGISTRY_URL} yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} DD_INSTALLER_REGISTRY_URL=${DD_INSTALLER_REGISTRY_URL} yum -y install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
       if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$agent_minor_version_without_patch" ]; then
         installed_minor=$($sudo_cmd rpm -q --queryformat '%{VERSION}' datadog-agent 2>/dev/null | cut -d. -f2)
         if [ -n "$installed_minor" ] && [ "$installed_minor" -ge 78 ]; then
@@ -1574,7 +1574,7 @@ END
 )"
     start_stage "install_agent_packages"
 
-    $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' DD_OTELCOLLECTOR_ENABLED='${DD_OTELCOLLECTOR_ENABLED}' apt-get install -o Acquire::Retries='5' -y --force-yes ${packages[*]} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
+    $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' DD_OTELCOLLECTOR_ENABLED='${DD_OTELCOLLECTOR_ENABLED}' DD_INSTALLER_REGISTRY_URL='${DD_INSTALLER_REGISTRY_URL}' apt-get install -o Acquire::Retries='5' -y --force-yes ${packages[*]} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
     if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$agent_minor_version_without_patch" ]; then
       installed_minor=$(dpkg-query -W -f='${Version}' datadog-agent 2>/dev/null | grep -oE '7\.[0-9]+' | head -1 | cut -d. -f2)
       if [ -n "$installed_minor" ] && [ "$installed_minor" -ge 78 ]; then
@@ -1751,9 +1751,9 @@ END
     fi
     # Not yet retry mechanism in zypper, see https://github.com/openSUSE/zypper/issues/420
     if [ -z "$sudo_cmd" ]; then
-      DD_OTELCOLLECTOR_ENABLED="${DD_OTELCOLLECTOR_ENABLED}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
+      DD_OTELCOLLECTOR_ENABLED="${DD_OTELCOLLECTOR_ENABLED}" DD_INSTALLER_REGISTRY_URL="${DD_INSTALLER_REGISTRY_URL}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
     else
-      $sudo_cmd DD_OTELCOLLECTOR_ENABLED="${DD_OTELCOLLECTOR_ENABLED}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE="${SYSTEMD_OFFLINE:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
+      $sudo_cmd DD_OTELCOLLECTOR_ENABLED="${DD_OTELCOLLECTOR_ENABLED}" DD_INSTALLER_REGISTRY_URL="${DD_INSTALLER_REGISTRY_URL}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE="${SYSTEMD_OFFLINE:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
     fi
 
     if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$agent_minor_version_without_patch" ]; then

--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -1233,7 +1233,8 @@ if [[ "$agent_flavor" == "datadog-fips-agent" ]]; then
     fi
 fi
 
-skip_ddot_package_install=
+ddot_use_installer=
+ddot_oci_tag="latest"
 if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
     if [ "$agent_major_version" != "7" ] || { [ -n "$agent_minor_version_without_patch" ] && [ "${agent_minor_version_without_patch}" -lt 69 ]; } then
         ERROR_MESSAGE="The datadog-agent-ddot is only available since version AGENT_MAJOR_VERSION_PLACEHOLDER.69.3 and requested minor version is $agent_minor_version"
@@ -1242,10 +1243,21 @@ if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
         report_telemetry
         exit 1;
     fi
-    # Starting from 7.78.0, DDOT is installed by the Agent post-install script
-    if [ -n "$agent_minor_version_without_patch" ] && [ "${agent_minor_version_without_patch}" -ge 78 ]; then
-        skip_ddot_package_install=true
+    # Starting from 7.78.0, DDOT is installed via datadog-installer extension install
+    if [ -z "$agent_minor_version_without_patch" ] || [ "${agent_minor_version_without_patch}" -ge 78 ]; then
+        ddot_use_installer=true
+        if [ -n "$agent_minor_version_without_patch" ]; then
+            ddot_oci_tag="${agent_major_version}.${clean_agent_minor_version}-1"
+        fi
     fi
+fi
+if [ -n "$TESTING_DDOT_OCI_TAG" ]; then
+    ddot_oci_tag="$TESTING_DDOT_OCI_TAG"
+fi
+if [ -n "$TESTING_APT_URL" ] || [ -n "$TESTING_YUM_URL" ]; then
+    ddot_oci_registry=${DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE:-"installtesting.datad0g.com"}
+else
+    ddot_oci_registry=${DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE:-$([[ "$DD_SITE" == "datad0g.com" ]] && echo "install.datad0g.com" || echo "install.datadoghq.com")}
 fi
 
 if [ -n "$remote_updates" ] && { [ -n "$agent_minor_version_without_patch" ] && [ "$agent_minor_version_without_patch" -lt 69 ]; }; then
@@ -1336,7 +1348,7 @@ if [ "$OS" == "Red Hat" ]; then
     # if some packages were previously pinned (using excludepkgs)
     # this will unpin them as a side effect
     $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://${yum_url}/${yum_version_path}/${ARCHI}/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=${rpm_repo_gpgcheck}\npriority=1\ngpgkey=${gpgkeys}' > /etc/yum.repos.d/datadog.repo"
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
       $sudo_cmd sh -c "echo -e '[datadog-ddot]\nname = Datadog, Inc.\nbaseurl = https://${yum_url}/${ddot_yum_version_path}/${ARCHI}/\nenabled=0\ngpgcheck=1\nrepo_gpgcheck=${rpm_repo_gpgcheck}\npriority=1\ngpgkey=${gpgkeys}' > /etc/yum.repos.d/datadog-ddot.repo"
     fi
 
@@ -1384,21 +1396,15 @@ END
 
     # packages can be empty if no_agent is set
     if [ ${#packages[@]} -ne 0 ]; then
-      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
         echo -e "  \033[33mInstalling package(s): ${packages[*]} ${ddot_package}\n\033[0m"
       else
         echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
       fi
 
       # yum has a default retry of 10 https://github.com/Distrotech/yum/blob/f4e54aeed297158c563828aa3ebb93d0c8ce7e38/docs/yum.conf.5#L364-L366
-      $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} DD_INSTALLER_REGISTRY_URL=${DD_INSTALLER_REGISTRY_URL} yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DD_OTELCOLLECTOR_ENABLED=${DD_OTELCOLLECTOR_ENABLED} DD_INSTALLER_REGISTRY_URL=${DD_INSTALLER_REGISTRY_URL} yum -y install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
-      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$agent_minor_version_without_patch" ]; then
-        installed_minor=$($sudo_cmd rpm -q --queryformat '%{VERSION}' datadog-agent 2>/dev/null | cut -d. -f2)
-        if [ -n "$installed_minor" ] && [ "$installed_minor" -ge 78 ]; then
-          skip_ddot_package_install=true
-        fi
-      fi
-      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+      $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} DD_INSTALLER_REGISTRY_URL=${DD_INSTALLER_REGISTRY_URL} yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DD_INSTALLER_REGISTRY_URL=${DD_INSTALLER_REGISTRY_URL} yum -y install $dnf_flag ${packages[*]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
+      if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
         $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} DATADOG_TRACE_ID=${DATADOG_TRACE_ID} DATADOG_PARENT_ID=${DATADOG_PARENT_ID} yum -y --disablerepo='*' --enablerepo='datadog-ddot' install $dnf_flag ${ddot_package}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) || $sudo_cmd bash -c "SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} yum -y install $dnf_flag ${ddot_package}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)
       fi
 
@@ -1463,7 +1469,7 @@ elif [ "$OS" == "Debian" ]; then
     $sudo_cmd sh -c "echo 'deb [signed-by=${apt_usr_share_keyring}] https://${apt_url}/ ${apt_repo_version}' > /etc/apt/sources.list.d/datadog.list"
     $sudo_cmd sh -c "chmod a+r /etc/apt/sources.list.d/datadog.list"
 
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
       printf "\033[34m\n* Installing APT package sources for Datadog DDOT\n\033[0m\n"
       $sudo_cmd sh -c "echo 'deb [signed-by=${apt_usr_share_keyring}] https://${apt_url}/ ${ddot_apt_repo_version}' > /etc/apt/sources.list.d/datadog-ddot.list"
       $sudo_cmd sh -c "chmod a+r /etc/apt/sources.list.d/datadog-ddot.list"
@@ -1514,7 +1520,7 @@ If the failing repository is Datadog, please contact Datadog support.
 *****
 "
     $sudo_cmd apt-get update -o Dir::Etc::sourcelist="sources.list.d/datadog.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
       $sudo_cmd apt-get update -o Dir::Etc::sourcelist="sources.list.d/datadog-ddot.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
       $sudo_cmd mv /etc/apt/sources.list.d/datadog-ddot.list /etc/apt/sources.list.d/datadog-ddot.list.disabled
     fi
@@ -1553,7 +1559,7 @@ If the cause is unclear, please contact Datadog support.
         $sudo_cmd rm -rf "/opt/datadog-agent/python-scripts/__pycache__"
     fi
 
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
       echo -e "  \033[33mInstalling package(s): ${packages[*]} ${ddot_package}\n\033[0m"
     else
       echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
@@ -1574,14 +1580,8 @@ END
 )"
     start_stage "install_agent_packages"
 
-    $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' DD_OTELCOLLECTOR_ENABLED='${DD_OTELCOLLECTOR_ENABLED}' DD_INSTALLER_REGISTRY_URL='${DD_INSTALLER_REGISTRY_URL}' apt-get install -o Acquire::Retries='5' -y --force-yes ${packages[*]} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$agent_minor_version_without_patch" ]; then
-      installed_minor=$(dpkg-query -W -f='${Version}' datadog-agent 2>/dev/null | grep -oE '7\.[0-9]+' | head -1 | cut -d. -f2)
-      if [ -n "$installed_minor" ] && [ "$installed_minor" -ge 78 ]; then
-        skip_ddot_package_install=true
-      fi
-    fi
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+    $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' DD_INSTALLER_REGISTRY_URL='${DD_INSTALLER_REGISTRY_URL}' apt-get install -o Acquire::Retries='5' -y --force-yes ${packages[*]} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
       $sudo_cmd mv /etc/apt/sources.list.d/datadog-ddot.list.disabled /etc/apt/sources.list.d/datadog-ddot.list
       $sudo_cmd bash -c "POLICYRCD='${POLICYRCD}' apt-get install -o Acquire::Retries='5' -y --force-yes ${ddot_package} 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2)"
       $sudo_cmd mv /etc/apt/sources.list.d/datadog-ddot.list /etc/apt/sources.list.d/datadog-ddot.list.disabled
@@ -1666,7 +1666,7 @@ elif [ "$OS" == "SUSE" ]; then
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"
   $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://${yum_url}/suse/${yum_version_path}/${ARCHI}\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=${rpm_repo_gpgcheck}\ngpgkey=${gpgkeys}' > /etc/zypp/repos.d/datadog.repo"
-  if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+  if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
     echo -e "\033[34m\n* Installing YUM Repository for DDOT\n\033[0m"
     $sudo_cmd sh -c "echo -e '[datadog-ddot]\nname=datadog-ddot\nenabled=0\nbaseurl=https://${yum_url}/suse/${ddot_yum_version_path}/${ARCHI}\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=${rpm_repo_gpgcheck}\ngpgkey=${gpgkeys}' > /etc/zypp/repos.d/datadog-ddot.repo"
   fi
@@ -1674,7 +1674,7 @@ elif [ "$OS" == "SUSE" ]; then
 
   echo -e "\033[34m\n* Refreshing repositories\n\033[0m"
   $sudo_cmd zypper --non-interactive --no-gpg-checks refresh datadog
-  if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+  if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
     $sudo_cmd zypper --non-interactive --no-gpg-checks refresh datadog-ddot
   fi
 
@@ -1744,25 +1744,19 @@ END
 )"
   start_stage "install_agent_packages"
   if [ ${#packages[@]} -ne 0 ]; then
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
       echo -e "  \033[33mInstalling package(s): ${packages[*]} ${ddot_package}\n\033[0m"
     else
       echo -e "  \033[33mInstalling package(s): ${packages[*]}\n\033[0m"
     fi
     # Not yet retry mechanism in zypper, see https://github.com/openSUSE/zypper/issues/420
     if [ -z "$sudo_cmd" ]; then
-      DD_OTELCOLLECTOR_ENABLED="${DD_OTELCOLLECTOR_ENABLED}" DD_INSTALLER_REGISTRY_URL="${DD_INSTALLER_REGISTRY_URL}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
+      DD_INSTALLER_REGISTRY_URL="${DD_INSTALLER_REGISTRY_URL}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
     else
-      $sudo_cmd DD_OTELCOLLECTOR_ENABLED="${DD_OTELCOLLECTOR_ENABLED}" DD_INSTALLER_REGISTRY_URL="${DD_INSTALLER_REGISTRY_URL}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE="${SYSTEMD_OFFLINE:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
+      $sudo_cmd DD_INSTALLER_REGISTRY_URL="${DD_INSTALLER_REGISTRY_URL}" ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE="${SYSTEMD_OFFLINE:-0}" zypper --non-interactive --no-refresh install "${packages[@]}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
     fi
 
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$agent_minor_version_without_patch" ]; then
-      installed_minor=$($sudo_cmd rpm -q --queryformat '%{VERSION}' datadog-agent 2>/dev/null | cut -d. -f2)
-      if [ -n "$installed_minor" ] && [ "$installed_minor" -ge 78 ]; then
-        skip_ddot_package_install=true
-      fi
-    fi
-    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$skip_ddot_package_install" ]; then
+    if [ -n "$DD_OTELCOLLECTOR_ENABLED" ] && [ -z "$ddot_use_installer" ]; then
       if [ -z "$sudo_cmd" ]; then
         ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" SYSTEMD_OFFLINE=${SYSTEMD_OFFLINE:-0} zypper --non-interactive --no-refresh install "${ddot_package}" 2> >($sudo_cmd tee /tmp/ddog_install_error_msg >&2) ||:
       else
@@ -2242,8 +2236,12 @@ fi
 
 # DDOT configuration update
 if [ -n "$DD_OTELCOLLECTOR_ENABLED" ]; then
-  update_ddot "$sudo_cmd" "$config_file"
-  manage_otel_config "$sudo_cmd" "$otel_config_file" "$apikey" "$site"
+  if [ -n "$ddot_use_installer" ]; then
+    $sudo_cmd datadog-installer extension install "oci://${ddot_oci_registry}/agent-package:${ddot_oci_tag}" "ddot"
+  else
+    update_ddot "$sudo_cmd" "$config_file"
+    manage_otel_config "$sudo_cmd" "$otel_config_file" "$apikey" "$site"
+  fi
 fi
 
 if [ -e "$(dirname $dd_environment_file)" ]; then


### PR DESCRIPTION
## Bug

For Agent >= 7.78.0, DDOT is installed by the Agent's own post-install script rather than the install script. The previous fix (#406) handled this by unsetting \`DD_OTELCOLLECTOR_ENABLED\`, which caused two regressions:

1. \`DD_OTELCOLLECTOR_ENABLED\` was no longer present in the environment when running \`apt-get\`/\`yum\`/\`zypper install datadog-agent\`, so the Agent's post-install script couldn't see it and wouldn't install DDOT
2. \`update_ddot\` and \`manage_otel_config\` were also skipped (they gate on \`DD_OTELCOLLECTOR_ENABLED\`), so the Datadog Agent config was not updated for DDOT

## Why not pass DD_OTELCOLLECTOR_ENABLED to the package manager?

An intermediate approach passed \`DD_OTELCOLLECTOR_ENABLED\` to the \`apt-get\`/\`yum\`/\`zypper\` install command so the Agent's post-install script could pick it up. This failed because the Agent post-install runs before the install script creates \`datadog.yaml\`, causing:

```
failed to install extensions: extension ddot: could not install extension: failed to run hook (postInstallExtension): run failed: failed to write otel-config.yaml: failed to read datadog.yaml: open /etc/datadog-agent/datadog.yaml: no such file or directory
```

## Fix

For Agent >= 7.78.0, instead of relying on the Agent post-install script:
- Do **not** pass \`DD_OTELCOLLECTOR_ENABLED\` to the package manager (avoids triggering the broken post-install)
- After \`datadog.yaml\` is created by the install script, call \`datadog-installer extension install "oci://\${ddot_oci_registry}/agent-package:\${ddot_oci_tag}" "ddot"\` directly — this handles both DDOT installation and configuration
- Skip the \`datadog-agent-ddot\` deb/rpm package install and repo setup (no longer needed)

For Agent < 7.78.0, behavior is unchanged: the \`datadog-agent-ddot\` package is installed from the dedicated apt/yum/zypper repo, and \`update_ddot\`/\`manage_otel_config\` run as before.

## Test plan
- [ ] With \`DD_OTELCOLLECTOR_ENABLED\` set and Agent < 7.78.0: ddot repo setup and package install run as before, \`update_ddot\`/\`manage_otel_config\` still run
- [ ] With \`DD_OTELCOLLECTOR_ENABLED\` set and Agent >= 7.78.0: ddot repo/package install are skipped, \`datadog-installer extension install\` is called after \`datadog.yaml\` is created
- [ ] Without \`DD_OTELCOLLECTOR_ENABLED\`: no behavior change