### PR TITLE
Transfer code ownership to fleet-automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 # Rules are matched bottom-to-top, so one team can own subdirectories
 # and another the rest of the directory.
 
-*  @DataDog/container-ecosystems @Datadog/telemetry-onboarding
+*  @DataDog/fleet-automation @Datadog/telemetry-onboarding


### PR DESCRIPTION
* Transfer code ownership of `agent-linux-install-script` to the @DataDog/fleet-automation team
* @DataDog/telemetry-onboarding as secondary until handover is complete
* Remove @DataDog/container-ecosystems team