### PR TITLE
fix(usm): prepend `service_monitoring_config` via heredoc

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -2147,12 +2147,16 @@ function update_usm(){
   local sudo_cmd="$1"
   local config_file="$2"
 
-  printf "\033[34m\n* Setting $nice_flavor configuration to enable Universal Service Monitoring: $config_file\n\033[0m\n"
-  $sudo_cmd cp "$config_file" "${config_file}.orig"
-  $sudo_cmd sed -i \
-    -e 's/^# service_monitoring_config:/service_monitoring_config:/' \
-    -e '/^service_monitoring_config:/,/^$/s/^\s*#\s*enabled: false/  enabled: true/' \
-    "$config_file"
+  if ! $sudo_cmd grep -q "^service_monitoring_config:" "$config_file"; then
+    $sudo_cmd cp "$config_file" "${config_file}.orig"
+    $sudo_cmd sh -c "exec cat - '${config_file}.orig' > '$config_file'" <<EOF
+service_monitoring_config:
+  enabled: true
+EOF
+    printf "\033[34m\n* Adding service_monitoring_config to the Datadog Agent configuration: $config_file\n\033[0m\n"
+  else
+    printf "\033[34m\n* service_monitoring_config configuration already exists in $config_file, skipping the update.\n\033[0m\n"
+  fi
 }
 function update_logs_config_process_collect_all(){
   local sudo_cmd="$1"


### PR DESCRIPTION
### What does this PR do?
Rewrites `update_usm` to strictly mirror `update_ddot` (below in the same file): guard with `grep -q "^<key>:"`, on miss prepend a fresh `<key>:\n  enabled: true` block via heredoc, on hit log a "configuration already exists" notice and skip.
Same structure, same `printf` phrasing, same idempotency guarantee.

### Motivation
The previous implementation enabled USM by editing the agent-shipped `system-probe.yaml.example` in place with `sed`:
```
    -e 's/^# service_monitoring_config:/service_monitoring_config:/' \
    -e '/^service_monitoring_config:/,/^$/s/^\s*#\s*enabled: false/  enabled: true/'
```
The second `sed` uses the address range `/^service_monitoring_config:/` through `/^$/` (header to next blank line).
DataDog/datadog-agent#48567 (merged 2026-04-01, milestone 7.79.0) inserted a blank line directly after every top-level key in `pkg/config/system-probe_template.yaml`, including `# service_monitoring_config:`.
After 7.79.0 was published on 2026-05-20 the range collapsed to a single line and the `enabled: false` -> `enabled: true` substitution **silently stopped firing**.

Customer impact: anyone curling `install_script_agent7.sh` with `DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED=true` against a 7.79.0+ agent ends up with USM disabled despite asking for it.

CI impact: DataDog/datadog-agent `test_install_script` is red on every build that runs it post-2026-05-20: 18 consecutive failures on main (since 20:11 UTC; last green at 04:13 UTC same day), 4 on 7.80.0-rc.3 (since 2026-05-22), 3 on 7.79.1-rc.1 (since 2026-05-26).
Both RC tags are blocked from shipping.

### Describe how you validated your changes
- regenerated `install_script_agent7.sh` via make and confirmed the heredoc-with-guard form is emitted at the expected line, byte-for- byte parallel to `update_ddot`'s first block,
- the prepended block is the same shape every sibling helper writes, so `TestInstallUSMSuite`'s assertion on `service_monitoring_config.enabled == true` continues to hold, independently of the template's layout,
- verified the agent's `pkg/config/system-probe_template.yaml` ships `# service_monitoring_config:` commented out on both main and the 7.79.0 tag, so `grep -q "^service_monitoring_config:"` is `false` on a fresh stock install and `true` on a re-run against our own prepended output.

### Additional Notes
- subtle behavior change vs the previous `sed`: on a re-run against a customer's already-uncommented `service_monitoring_config:` block, the old code would force-flip a commented `# enabled: false` inside that block to `enabled: true`; the new code skips outright. Aligns with `update_ddot`'s "leave existing top-level keys alone" policy.
- `set_privileged_logs` and `set_discovery` (above `update_usm`) share the duplicate-key footgun this PR closes for `update_usm`; fixing them is out of scope here but worth a follow-up.
- a `shunit2` unit test exercising `update_usm` would catch this class of regression earlier; out of scope for this hotfix.
- #430 (open) is the complementary test-infra change that makes the e2e suite exercise the agent version under test rather than the latest released agent, closing the six-week latency between the regression landing on datadog-agent main (2026-04-01) and surfacing through the `install-script` e2e suite (2026-05-20).
- install.datadoghq.com serves the latest tagged release (1.45.0 today), so this merge alone does not reach customers; cutting 1.45.1 is the customer-facing remediation. The datadog-agent `test_install_script` job triggers the child pipeline with `--git-ref main`, so CI there will turn green immediately after merge.