### PR TITLE
fix(install_script): enable remote_configuration when remote_updates is set

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -2076,6 +2076,12 @@ function update_remote_updates(){
     else
       echo "remote_updates: $remote_updates" | $sudo_cmd tee -a "$config_file" > /dev/null
     fi
+    # On GovCloud (ddog-gov.com), remote_configuration.enabled defaults to false and must be
+    # explicitly set. Without it the installer daemon crashes at startup with
+    # "remote config is required to create the updater".
+    if ! $sudo_cmd grep -qE "^remote_configuration:" "$config_file"; then
+      printf "remote_configuration:\n  enabled: true\n" | $sudo_cmd tee -a "$config_file" > /dev/null
+    fi
   fi
 }
 function update_security_and_or_compliance(){


### PR DESCRIPTION
## Problem

When `DD_REMOTE_UPDATES=true` is used on GovCloud (`ddog-gov.com`), the `datadog-agent-installer` service crashes immediately at startup with:

```
{"error":"remote config is required to create the updater","code":0}
```

Root cause: `IsRemoteConfigEnabled()` in `pkg/config/utils/miscellaneous.go` has an explicit opt-in gate for GovCloud:

```go
if IsFed(cfg) && !cfg.IsConfigured("remote_configuration.enabled") {
    return false
}
```

The install script sets `remote_updates: true` in `datadog.yaml` but never sets `remote_configuration.enabled: true`. On commercial the latter defaults to `true`, but on GovCloud it must be explicitly configured.

## Fix

When writing `remote_updates: true`, also append `remote_configuration.enabled: true` if not already present. This is a no-op on commercial (where RC is already enabled by default) and unblocks GovCloud installs.

## Test

Install on a GovCloud Ubuntu VM with `DD_REMOTE_UPDATES=true DD_SITE=ddog-gov.com`:
- Before: `datadog-agent-installer` crashes immediately in a restart loop
- After: `datadog-agent status` shows Remote Configuration connected; `datadog-agent-installer` starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)