### PR TITLE
Add DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT env var

### DIFF
--- a/install_script.sh.template
+++ b/install_script.sh.template
@@ -976,6 +976,11 @@ if [ -n "$DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST" ]; then
   par_actions_allowlist=$DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST
 fi
 
+par_api_key_only_enrollment=
+if [ -n "$DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT" ]; then
+  par_api_key_only_enrollment=$DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT
+fi
+
 ##
 # INSTALL SCRIPT CONFIGURATION OPTIONS
 # Technical options to test with non-production values for signature keys, packages or reporting telemetry.
@@ -2211,6 +2216,7 @@ function update_par(){
   local config_file="$2"
   local par_enabled="$3"
   local par_actions_allowlist="$4"
+  local par_api_key_only_enrollment="$5"
 
   if [ "$par_enabled" != "true" ]; then
     return
@@ -2240,6 +2246,10 @@ function update_par(){
     done
     par_config="${par_config}
   actions_allowlist:${actions_append}"
+  fi
+  if [ -n "$par_api_key_only_enrollment" ]; then
+    par_config="${par_config}
+  api_key_only_enrollment: ${par_api_key_only_enrollment}"
   fi
   $sudo_cmd sh -c "cat >> '$config_file'" <<EOF
 
@@ -2348,7 +2358,7 @@ elif [ ! "$no_agent" ]; then
       update_logs_config_process_collect_all "$sudo_cmd" "$config_file"
     fi
     update_remote_updates "$sudo_cmd" "$remote_updates" "$config_file"
-    update_par "$sudo_cmd" "$config_file" "$par_enabled" "$par_actions_allowlist"
+    update_par "$sudo_cmd" "$config_file" "$par_enabled" "$par_actions_allowlist" "$par_api_key_only_enrollment"
   fi
 
   # DD_LOGS_CONFIG_PROCESS_COLLECT_ALL needs discovery to be enabled

--- a/unit_tests/test_install_script.sh
+++ b/unit_tests/test_install_script.sh
@@ -401,6 +401,22 @@ testParConfigAlreadyExists() {
   # Should not modify existing config
   assertEquals "$(sudo yq eval '.private_action_runner.enabled' $config_file)" "false"
 }
+testParEnabledWithApiKeyOnlyEnrollment() {
+  sudo rm $config_file 2> /dev/null
+  ensure_config_file_exists "sudo" $config_file "dd-agent"
+  update_par "sudo" $config_file "true" "" "true"
+  yamllint -c "$yaml_config" --no-warnings $config_file
+  assertEquals 0 $?
+  assertEquals "$(sudo yq eval '.private_action_runner.enabled' $config_file)" "true"
+  assertEquals "$(sudo yq eval '.private_action_runner.api_key_only_enrollment' $config_file)" "true"
+}
+testParEnabledWithoutApiKeyOnlyEnrollment() {
+  sudo rm $config_file 2> /dev/null
+  ensure_config_file_exists "sudo" $config_file "dd-agent"
+  update_par "sudo" $config_file "true" ""
+  # Should not add api_key_only_enrollment when not provided
+  assertEquals "$(sudo yq eval '.private_action_runner.api_key_only_enrollment' $config_file)" "null"
+}
 
 # shellcheck source=/dev/null
 . shunit2


### PR DESCRIPTION
## Summary
- Adds a new `DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT` env var to set `private_action_runner.api_key_only_enrollment` in `datadog.yaml` at install time, following the same pattern as the existing `DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST` env var.

## Test plan
- [x] Added unit tests covering PAR enabled with and without `api_key_only_enrollment` set (`testParEnabledWithApiKeyOnlyEnrollment`, `testParEnabledWithoutApiKeyOnlyEnrollment`)