### PR TITLE
[ACIX-1926] chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           scope: DataDog/agent-linux-install-script
           policy: self.slapr.run-slapr
-      - uses: DataDog/slapr@4b5efe2ce585e45898bb88c4fa303e226e8199e4 # master
+      - uses: DataDog/slapr@4b5efe2ce585e45898bb88c4fa303e226e8199e4 # 1.0.0
         env:
           GITHUB_TOKEN: "${{ steps.octo-sts.outputs.token }}"
           SLACK_CHANNEL_ID: "${{ vars.SLACK_CHANNEL_ID }}"


### PR DESCRIPTION
Mechanical rewrite of every `uses:` reference to a full-length commit SHA, produced by [pinact](https://github.com/suzuki-shunsuke/pinact). An unpinned reference resolves to a mutable ref, so a compromise of the upstream action becomes code execution in this repository's CI.

The trailing `# vX.Y.Z` comment is what lets Renovate and Dependabot keep these bumped, so please keep it.

**One thing to check:** references that tracked `@main` or `@master` were resolved to the latest stable tag. If any of them floated deliberately and that behaviour was load-bearing here, say so on the PR and we will revert that line.
