### PR TITLE
Revert "Revert "Make sure we keep the testing params when extra params does not override minor version""

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -109,7 +109,7 @@ func (s *linuxInstallerTestSuite) InstallAgent(agentVersion int, extraParam ...s
 	}
 
 	extraParamLength := len(extraParam)
-	if agentVersion == 7 && extraParamLength == 0 {
+	if agentVersion == 7 && !strings.Contains(strings.Join(extraParam, " "), "DD_AGENT_MINOR_VERSION") { // If DD_AGENT_MINOR_VERSION is set, we need to not set the testing variables
 		if val, ok := os.LookupEnv("TESTING_YUM_VERSION_PATH"); ok {
 			scriptEnvVariable = scriptEnvVariable + fmt.Sprintf(" TESTING_YUM_VERSION_PATH='%s'", val)
 		}


### PR DESCRIPTION
Reverts DataDog/agent-linux-install-script#436

The issue is being fixed in https://github.com/DataDog/datadog-agent/pull/54908.