### PR TITLE
CI: use xz -T instead of pxz

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ go_e2e_deps:
     - if [ -f modcache_e2e.tar.xz  ]; then exit 0; fi
     - source /root/.bashrc
     - cd test/e2e && go mod download
-    - cd $GOPATH/pkg/mod/ && tar c -I "pxz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_e2e.tar.xz .
+    - cd $GOPATH/pkg/mod/ && tar c -I "xz -T${KUBERNETES_CPU_REQUEST}" -f $CI_PROJECT_DIR/modcache_e2e.tar.xz .
   artifacts:
     expire_in: 1 day
     paths:


### PR DESCRIPTION
This flag has been supported by the regular xz tool for a while, no need for a special tool for MT compression

Fix issues with new build images: https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/2003074882 (I suppose, the root cause isn't clearly identified, but the change still makes sense IMHO)